### PR TITLE
Add create and update timestamps to Model

### DIFF
--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -267,6 +267,24 @@ class Model(metaclass=ModelMeta):
         else:
             self._key = p
 
+    def get_firestore_create_time(self):
+        """returns create time of document in Firestore
+
+        Returns:
+            :class:`google.api_core.datetime_helpers.DatetimeWithNanoseconds`,
+            :class:`datetime.datetime` or ``NoneType``:
+        """
+        return self._meta._firestore_create_time
+
+    def get_firestore_update_time(self):
+        """returns update time of document in Firestore
+
+        Returns:
+            :class:`google.api_core.datetime_helpers.DatetimeWithNanoseconds`,
+            :class:`datetime.datetime` or ``NoneType``:
+        """
+        return self._meta._firestore_update_time
+
     def list_subcollections(self):
         """return a list of any subcollections of the doc"""
         if self._meta._referenceDoc is not None:

--- a/src/fireo/models/model_meta.py
+++ b/src/fireo/models/model_meta.py
@@ -144,6 +144,8 @@ class ModelMeta(type):
                 self.missing_field = 'merge'
                 self.to_lowercase = False
                 self._referenceDoc = None
+                self._firestore_create_time = None
+                self._firestore_update_time = None
 
             # Attached manager to model class
             # later on manager can be accessible via class `collection` attribute

--- a/src/fireo/queries/query_wrapper.py
+++ b/src/fireo/queries/query_wrapper.py
@@ -53,6 +53,10 @@ class ModelWrapper:
             setattr(model, '_id', doc.id)
             # save the firestore reference doc so that further actions can be performed (i.e. collections())
             model._meta.set_reference_doc(doc.reference)
+            # even though doc.reference currently points to self, there is no guarantee this will be true
+            # in the future, therefore we should store the create time and update time separate.
+            model._meta._firestore_create_time = doc.create_time
+            model._meta._firestore_update_time = doc.update_time
         return model
 
 

--- a/src/tests/v110/test_create_and_update_time.py
+++ b/src/tests/v110/test_create_and_update_time.py
@@ -1,0 +1,57 @@
+import fireo
+from fireo.fields import TextField
+from fireo.models import Model
+
+"""Tests the creating and updating of firestore create and update timestamps"""
+def test_create_and_update_time():
+    class Doc(Model):
+      doc_id = TextField()
+      
+      class Meta:
+          collection_name = "doc_time"
+
+    doc = Doc(doc_id="test")
+
+    # ensure the create and update are None for new doc
+    assert doc.get_firestore_create_time() is None
+    assert doc.get_firestore_update_time() is None
+
+    doc.save()
+
+    # ensure the create and update time are set and are equal
+    assert doc.get_firestore_create_time() is not None
+    assert doc.get_firestore_update_time() is not None
+    assert doc.get_firestore_create_time() == doc.get_firestore_update_time()
+
+    create_timestamp_before_update = doc.get_firestore_create_time()
+    doc.doc_id = "test 2"
+
+    # ensure modifying a field doesn't change the update time for Firestore
+    assert doc.get_firestore_create_time() is not None
+    assert doc.get_firestore_update_time() is not None
+    assert doc.get_firestore_create_time() == create_timestamp_before_update
+    assert doc.get_firestore_create_time() == doc.get_firestore_update_time()
+
+    doc.update()
+
+    # ensure that the update triggers and an update of the update timestamp
+    # and that the original create timestamp is still the same
+    assert doc.get_firestore_create_time() is not None
+    assert doc.get_firestore_update_time() is not None
+    assert doc.get_firestore_create_time() == create_timestamp_before_update
+    assert doc.get_firestore_create_time() != doc.get_firestore_update_time()
+
+    last_create_time = doc.get_firestore_create_time()
+    last_update_time = doc.get_firestore_update_time()
+    doc_key = doc.key
+
+    queried_doc = Doc.collection.get(doc_key)
+
+    # ensure the queried doc has the correct create and update timestamp
+    assert queried_doc.get_firestore_create_time() is not None
+    assert queried_doc.get_firestore_update_time() is not None
+    assert queried_doc.get_firestore_create_time() == last_create_time
+    assert queried_doc.get_firestore_update_time() == last_update_time
+
+
+


### PR DESCRIPTION
**What is the problem being addressed?**
Currently, there is no way to query the Firestore create and update timestamps for a model instance.  

**How the fix is applied:**
Two new methods were created on the Model class:
```
get_firestore_create_time()
get_firestore_update_time()
```
These methods return None or an instance of `google.api_core.datetime_helpers.DatetimeWithNanoseconds` (which extends `datetime.datetime`).

The actual values are stored in the meta class of the Model.

