### PR TITLE
fix for updating a TextField to an empty string

### DIFF
--- a/src/fireo/queries/update_query.py
+++ b/src/fireo/queries/update_query.py
@@ -55,7 +55,7 @@ class UpdateQuery(BaseQuery):
                 self._nested_field_list(f, field_dict, f.name)
             else:
                 v = f.get_value(self.query.get(f.name), ignore_required=True, ignore_default=True)
-                if v or type(v) is bool:
+                if v is not None or type(v) is bool:
                     field_dict[f.db_column_name] = v
         return field_dict
 


### PR DESCRIPTION
steps to reproduce

class User(Model):
    name = mdl.TextField()

u = User()
u.name = "Azeem"
u.save()
u.name = ""
u.update()

because an empty string is not "truthy" in python _parse_field() in UpdateQuery skips it and it is not updated in Firestore.