### PR TITLE
fix for MapField queries

### DIFF
--- a/src/fireo/queries/filter_query.py
+++ b/src/fireo/queries/filter_query.py
@@ -177,7 +177,8 @@ class FilterQuery(BaseQuery):
                     field_name = nested_model._meta.get_field(
                         field).db_column_name
                 else:
-                    f_name = model_name + '.' + field_name
+                    field_name = field
+                f_name = model_name + '.' + field_name
             else:
                 f_name = self.model._meta.get_field(name).db_column_name
             filters.append((f_name, op, val))

--- a/src/fireo/queries/filter_query.py
+++ b/src/fireo/queries/filter_query.py
@@ -173,7 +173,7 @@ class FilterQuery(BaseQuery):
 
                     model_names.append(name)
                 model_name = '.'.join(model_names)
-                if nested_models is not None:
+                if nested_model is not None:
                     field_name = nested_model._meta.get_field(
                         field).db_column_name
                 else:

--- a/src/fireo/queries/filter_query.py
+++ b/src/fireo/queries/filter_query.py
@@ -1,4 +1,5 @@
 from fireo.database import db
+from fireo.fields import NestedModel
 from fireo.fields.errors import FieldNotFound
 from fireo.queries import query_wrapper
 from fireo.queries.base_query import BaseQuery
@@ -166,13 +167,17 @@ class FilterQuery(BaseQuery):
                     except FieldNotFound:
                         model_field = nested_model._meta.get_field(m)
 
-                    nested_model = model_field.nested_model
+                    if isinstance(model_field, NestedModel):
+                        nested_model = model_field.nested_model
                     name = model_field.db_column_name
 
                     model_names.append(name)
                 model_name = '.'.join(model_names)
-                field_name = nested_model._meta.get_field(field).db_column_name
-                f_name = model_name + '.' + field_name
+                if nested_models is not None:
+                    field_name = nested_model._meta.get_field(
+                        field).db_column_name
+                else:
+                    f_name = model_name + '.' + field_name
             else:
                 f_name = self.model._meta.get_field(name).db_column_name
             filters.append((f_name, op, val))

--- a/src/tests/v118/nested_map_field_query_test.py
+++ b/src/tests/v118/nested_map_field_query_test.py
@@ -1,0 +1,27 @@
+from fireo.fields import TextField, MapField, NestedModel
+from fireo.models import Model
+
+
+class User(Model):
+    name = TextField()
+
+
+class Student(Model):
+    address = TextField()
+    user = NestedModel(User)
+    classes = MapField()
+
+
+def test_query_nested_and_map():
+    u = User(name='Nested_Model')
+
+    s = Student(address="Student_address")
+    s.user = u
+    s.classes = {"physics": 101,
+                 "history": 201,
+                 "physics": 404}
+    s.save()
+    value = Student.collection.filter("user.name", "==", "Nested_Model").get()
+    assert value.user.name == "Nested_Model"
+    value = Student.collection.filter("classes.physics", ">", 400).get()
+    assert value.user.name == "Nested_Model"


### PR DESCRIPTION
The following scenario throws an exception:

class User(Model):
    name = TextField()
    classes = MapField()

u = User()
u.name = "Azeem"
u.classes = {"physics": 101}
u.save()

User.collection.filter("classes.physics", ">", 100)

parse_where() is expecting a NestedModel, but is provided a MapField that is missing the nested_model attribute.

