### PR TITLE
refix issue #48: field_attribute validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.5',
+    version='1.2.6',
 
     description="FireO ORM is specifically designed for the Google's Firestore",
     long_description=long_description,

--- a/src/fireo/fields/base_field.py
+++ b/src/fireo/fields/base_field.py
@@ -117,7 +117,7 @@ class Field(metaclass=MetaField):
         -------
             DB value
         """
-        if val is not None or not ignore_required:
+        if val is not None or not ignore_required or self.field_attribute.default:
             val = self.field_attribute.parse(val, ignore_required, ignore_default)
         return self.db_value(val)
 

--- a/src/fireo/fields/base_field.py
+++ b/src/fireo/fields/base_field.py
@@ -117,8 +117,9 @@ class Field(metaclass=MetaField):
         -------
             DB value
         """
-        v = self.field_attribute.parse(val, ignore_required, ignore_default)
-        return self.db_value(v)
+        if val is not None or not ignore_required:
+            val = self.field_attribute.parse(val, ignore_required, ignore_default)
+        return self.db_value(val)
 
     def db_value(self, val):
         """How the value is going to save in firestore

--- a/src/fireo/fields/number_field.py
+++ b/src/fireo/fields/number_field.py
@@ -38,14 +38,14 @@ class NumberField(Field):
 
     def attr_int_only(self, attr_val, field_val):
         """Method for attribute int_only"""
-        if attr_val and field_val is not None and type(field_val) is not int:
+        if attr_val and type(field_val) is not int:
             raise errors.InvalidFieldType(f'Invalid field type. Field "{self.name}" expected {int} type, '
                                           f'got {type(field_val)}')
         return field_val
 
     def attr_float_only(self, attr_val, field_val):
         """Method for attribute float_only"""
-        if attr_val and field_val is not None and type(field_val) is not float:
+        if attr_val and type(field_val) is not float:
             raise errors.InvalidFieldType(f'Invalid field type. Field "{self.name}" expected {float} type, '
                                           f'got {type(field_val)}')
         return field_val

--- a/src/fireo/fields/text_field.py
+++ b/src/fireo/fields/text_field.py
@@ -31,9 +31,6 @@ class TextField(Field):
 
     def attr_max_length(self, attr_val, field_val):
         """Method for attribute max_length"""
-        if field_val is None:
-            return field_val
-            
         return field_val[:attr_val]
 
     def attr_to_lowercase(self, attr_val, field_val):

--- a/src/tests/v12/test_fix_update_with_none_value.py
+++ b/src/tests/v12/test_fix_update_with_none_value.py
@@ -1,21 +1,40 @@
+import pytest
+
 from fireo.models import Model
 from fireo.fields.text_field import TextField
 from fireo.fields.number_field import NumberField
+from fireo.fields.errors import NumberRangeError
 
 
 def test_fix_issue_48():
     class Person(Model):
         name = TextField(required=True, max_length=10)
-        type = NumberField(required=True, int_only=True)
+        type = NumberField(required=True, int_only=True, range=(1, 2))
 
-
-    person = Person.collection.create(name="test", type=1)
+    # test TextField
+    person = Person.collection.create(name='test', type=1)
 
     assert person.name == 'test'
     assert person.type == 1
 
-    person.type = 123
+    person.type = 2
     person.update()
 
     assert person.name == 'test'
-    assert person.type == 123
+    assert person.type == 2
+
+    # test NumberField
+    person = Person.collection.create(name='test', type=1)
+
+    assert person.name == 'test'
+    assert person.type == 1
+
+    person.name = 'test2'
+    person.update()
+
+    assert person.name == 'test2'
+    assert person.type == 1
+
+    person.type = 3
+    with pytest.raises(NumberRangeError):
+        person.update()


### PR DESCRIPTION
Previous fix does not always work.

For example when NumberField has range attribute:
```
class Person(Model):
    name = fields.TextField(required=True)
    type = fields.NumberField(required=True, int_only=True, range=(1, 2))

person = Person.collection.create(name="test", type=1)
person.name = "test2"
person.update()  # TypeError: '<' not supported between instances of 'NoneType' and 'int'
```