### PR TITLE
Fix expression ORM to ODM

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <p>
     <h1 align="center"><img src="fireo_logo.png" height="100" alt="FireO Logo"></h1>
     <p align="center">
-        A modern and simplest convenient ORM package in Python.
-        FireO is specifically designed for the Google's Firestore, it's more than just ORM.
+        A modern and simplest convenient ODM package in Python.
+        FireO is specifically designed for the Google's Firestore, it's more than just ODM.
         It implements validation, type checking, relational model logic and much more facilities.
     </p>
     <p align="center">

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     ],
 
     # What does your project relate to?
-    keywords='Python Firestore Models ORM Google Cloud Firebase',
+    keywords='Python Firestore Models ODM Google Cloud Firebase',
 
     # Add all packages except tests
     packages=find_packages('src', exclude=['tests']),


### PR DESCRIPTION
FireStore is document database, not relational database. So FireO should be explained as ODM(Object Document Mapper), not ORM(Object Relational Mapper).
I fixed the explanation. Would you check them?
