### PR TITLE
Adding validator_kwargs to FieldAttribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.4.4',
+    version='1.4.5',
 
     description="FireO ORM is specifically designed for the Google's Firestore.",
     long_description=long_description,

--- a/src/tests/v145/Pipfile
+++ b/src/tests/v145/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.7"

--- a/src/tests/v145/test_pass_validator_kwargs.py
+++ b/src/tests/v145/test_pass_validator_kwargs.py
@@ -1,0 +1,24 @@
+from fireo import fields
+from fireo.models import Model
+
+def validator_func_with_kwargs(a, **kwargs):
+    if kwargs.get("some_key"):
+        return True
+
+
+    return True
+
+
+class Test(Model): 
+    name = fields.TextField(required=True, validator=validator_func_with_kwargs, validator_kwargs={"some_key": "some_val"})
+
+    class Meta:
+        ignore_none_field = False
+
+
+def test_pass_validator_kwargs():
+    test = Test()
+    test.name = "test"
+    test.save()
+
+


### PR DESCRIPTION
Adding `validator_kwargs` to `FieldAttribute` so that fields can be the validator function can take in multiple params besides just the field value itself. This allows validation on multiple arguments, or allows passing in extraneous metadata required for the vaildator function. 



