### PR TITLE
Add Google credentials info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ space for collaboration, and contributors are expected to adhere to the
 3. Mention in [Documentation](https://github.com/octabytes/FireO/tree/gh-pages), what you have done and how other can use it  
 
 To run the tests while developing on this package, you'll have to setup a Google service account and setup credentials with the following command:
+
 `export GOOGLE_APPLICATION_CREDENTIALS="KEY_PATH"`
 
 See the [Google Cloud documentation](https://cloud.google.com/docs/authentication/getting-started) for more details.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ space for collaboration, and contributors are expected to adhere to the
 
 1. Fix bug or add new features
 2. Write tests for your functionality
-3. Mention in [Documentation](https://github.com/octabytes/FireO/tree/gh-pages), what you has done and how other can use it  
+3. Mention in [Documentation](https://github.com/octabytes/FireO/tree/gh-pages), what you have done and how other can use it  
+
+To run the tests while developing on this package, you'll have to setup a Google service account and setup credentials with the following command:
+`export GOOGLE_APPLICATION_CREDENTIALS="KEY_PATH"`
+
+See the [Google Cloud documentation](https://cloud.google.com/docs/authentication/getting-started) for more details.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ space for collaboration, and contributors are expected to adhere to the
 
 1. Fix bug or add new features
 2. Write tests for your functionality
-3. Mention in [Documentation](https://github.com/octabytes/FireO/tree/gh-pages), what you have done and how other can use it  
+3. Mention in [Documentation](https://github.com/octabytes/FireO/tree/gh-pages), what you have done and how others can use it  
 
 To run the tests while developing on this package, you'll have to setup a Google service account and setup credentials with the following command:
 


### PR DESCRIPTION
Added a small section about setting up Google credentials to the README. Ran into this while working on the package earlier and didn't see it mentioned anywhere. 