### PR TITLE
Setup gcloud in Github actions

### DIFF
--- a/.github/workflows/python-package-testing.yml
+++ b/.github/workflows/python-package-testing.yml
@@ -5,9 +5,7 @@ name: Python package
 
 on:
   push:
-    branches:
-      - master
-      - gcloud
+    branches: [master]
   pull_request:
     branches: [master]
 
@@ -35,18 +33,20 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
-      - name: Use gcloud CLI
+      - name: Display GCP setup properties
         run: gcloud info
 
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
           node-version: "14.x"
+
       - name: Start Firestore emulator
         run: |
           npm i -g firebase firebase-tools
           firebase setup:emulators:firestore
           firebase emulators:start --only firestore &
+
       - name: Test with pytest
         run: |
           pytest

--- a/.github/workflows/python-package-testing.yml
+++ b/.github/workflows/python-package-testing.yml
@@ -16,16 +16,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
-      - name: Use gcloud CLI
-        run: gcloud info
-
       - uses: actions/checkout@v2
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
@@ -37,6 +27,17 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest
           python -m pip install -e .
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Use gcloud CLI
+        run: gcloud info
+
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/python-package-testing.yml
+++ b/.github/workflows/python-package-testing.yml
@@ -5,7 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - gcloud
   pull_request:
     branches: [master]
 

--- a/.github/workflows/python-package-testing.yml
+++ b/.github/workflows/python-package-testing.yml
@@ -14,6 +14,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Use gcloud CLI
+        run: gcloud info
+
       - uses: actions/checkout@v2
       - name: Set up Python 3.7
         uses: actions/setup-python@v2


### PR DESCRIPTION
Resolves #123 
#### Description
- The previous github actions runs described in the issue were failing because the default credentials could not be found. I've found that the most reliable way to manage setting up the Google Cloud SDK is through [`setup-gcloud`  ](https://github.com/google-github-actions/setup-gcloud). 
- To make the SDK setup properly, you'll have to add `GCP_PROJECT_ID` and `GCP_SA_KEY` as github secrets. More info can be found on the `setup-gcloud` README
  - Note that `GCP_PROJECT_ID` has to be a valid project id
  - Also I recommend using Base64 encoding for the JSON content in `GCP_SA_KEY`. Github scrubs the logs of the secrets info but just to make sure. [Thread on this](https://github.com/google-github-actions/setup-gcloud/issues/134)
 - Another interesting issue that I was running into is described [here](https://github.com/googleapis/python-secret-manager/issues/82). Basically `setup-gcloud` must be intialized after the python setup or else the python venv won't contain the credentials set by `setup-gcloud`
 
#### Testing
- You can see a successful build with pytest on [my fork](https://github.com/isaacna/FireO/runs/3526628311?check_suite_focus=true)