### PR TITLE
Bump version of google-cloud-firestore to support python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,5 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['google-cloud-firestore==2.1.0'],
+    install_requires=['google-cloud-firestore==2.1.2'],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.4.6',
+    version='1.4.7',
 
     description="FireO ORM is specifically designed for the Google's Firestore.",
     long_description=long_description,


### PR DESCRIPTION
Hey guys

As I am using Python 3.10 in my projects, fireo needs to upgrade google-cloud-firestore to a slighly newer version:

`ERROR: Could not find a version that matches protobuf<3.18.0,>=3.12.0,>=3.19.0 (from proto-plus==1.19.7->google-cloud-firestore==2.1.0->fireo==1.4.6->-r /tmp/pipenvhgdtef30requirements/pipenv-5ac65p7k-constraints.txt (line 6))`