### PR TITLE
Allow to use mixins

### DIFF
--- a/src/fireo/models/model_meta.py
+++ b/src/fireo/models/model_meta.py
@@ -335,6 +335,8 @@ class ModelMeta(type):
         # Both Model user and student now contains the name field
         #
         for b in base:
+            if not hasattr(b, '_meta'):
+                continue
             if not b._meta.abstract:
                 from fireo.models import Model
                 if b != Model:


### PR DESCRIPTION
We need this if in case if we want to inherit from Model + some mixin.
For example:
```
from flask_login import UserMixin

class User(Model, UserMixin):
    username = TextField()
    password = TextField()

```