### PR TITLE
upgrade google-cloud-firestore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,5 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['google-cloud-firestore==2.2.0'],
+    install_requires=['google-cloud-firestore>=2.2.0'],
 )


### PR DESCRIPTION
Version which is required by FireO currently has an issue connecting to local firebase emulator.
I tried to use currently available (2.3.4) which works perfectly fine.