### PR TITLE
Documented utils.generateKeyFromId

### DIFF
--- a/utils.md
+++ b/utils.md
@@ -35,3 +35,10 @@ Get `id` from `key`
 ```python
 id = utils.get_id(key)
 ```
+
+## Key from id and model
+Get `key` from `id` and `model`
+
+```python
+key = utils.generateKeyFromId(model, key)
+```

--- a/utils.md
+++ b/utils.md
@@ -39,6 +39,8 @@ id = utils.get_id(key)
 ## Key from id and model
 Get `key` from `id` and `model`
 
+Simply concatenates `model.collection_name` and `id` so cannot derive the full `key` for models used in subcollections.
+
 ```python
 key = utils.generateKeyFromId(model, key)
 ```


### PR DESCRIPTION
I found it mentioned in this issue here: https://github.com/octabytes/FireO/issues/100
Figured it would be helpful to have in the docs. This was useful for class methods if you're setting a different collection name but aren't using sub-collections.

I added a clarifying comment that it doesn't work in sub-collections as mentioned here?
https://github.com/octabytes/FireO/issues/100