### PR TITLE
Fix transaction or batch. Unlock upgrade client to 2.3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,5 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['google-cloud-firestore==2.2.0'],
+    install_requires=['google-cloud-firestore<=2.3.4'],
 )

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,5 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['google-cloud-firestore<=2.3.4'],
+    install_requires=['google-cloud-firestore>=2.2.0,<=2.3.4'],
 )

--- a/src/fireo/queries/create_query.py
+++ b/src/fireo/queries/create_query.py
@@ -131,7 +131,7 @@ class CreateQuery(BaseQuery):
     def _raw_exec(self, transaction_or_batch=None, merge=None):
         """save model into firestore and return the document"""
         ref = self._doc_ref()
-        if transaction_or_batch:
+        if transaction_or_batch is not None:
             if merge:
                 transaction_or_batch.set(
                     ref, self._parse_field(), merge=merge)
@@ -153,6 +153,6 @@ class CreateQuery(BaseQuery):
 
     def exec(self, transaction_or_batch=None, merge=None):
         """return modified or new instance of model"""
-        if transaction_or_batch:
+        if transaction_or_batch is not None:
             return self._raw_exec(transaction_or_batch, merge)
         return query_wrapper.ModelWrapper.from_query_result(self.model, self._raw_exec(merge=merge))

--- a/src/fireo/queries/delete_query.py
+++ b/src/fireo/queries/delete_query.py
@@ -45,7 +45,7 @@ class DeleteQuery(BaseQuery):
             for c in ref.collections():
                 DeleteQuery(self.model_cls, query=c, child=True).exec(self.transaction_or_batch)
 
-        if self.transaction_or_batch:
+        if self.transaction_or_batch is not None:
             self.transaction_or_batch.delete(ref)
         else:
             ref.delete()
@@ -62,7 +62,7 @@ class DeleteQuery(BaseQuery):
                 for c in ref.collections():
                     DeleteQuery(self.model_cls, query=c, child=True).exec(self.transaction_or_batch)
 
-            if self.transaction_or_batch:
+            if self.transaction_or_batch is not None:
                 self.transaction_or_batch.delete(ref)
             else:
                 ref.delete()

--- a/src/fireo/queries/query_set.py
+++ b/src/fireo/queries/query_set.py
@@ -52,7 +52,7 @@ class QuerySet:
         Model instance:
             modified instance or new instance if no mutable instance provided
         """
-        transaction_or_batch = transaction if transaction else batch
+        transaction_or_batch = transaction if transaction is not None else batch
         return CreateQuery(self.model_cls, mutable_instance, no_return, **kwargs).exec(transaction_or_batch, merge)
 
     def update(self, mutable_instance=None, transaction=None, batch=None, **kwargs):
@@ -80,7 +80,7 @@ class QuerySet:
         Model instance:
             updated modified instance
         """
-        transaction_or_batch = transaction if transaction else batch
+        transaction_or_batch = transaction if transaction is not None else batch
         return UpdateQuery(self.model_cls, mutable_instance, **kwargs).exec(transaction_or_batch)
 
     def get(self, key, transaction=None):
@@ -130,6 +130,6 @@ class QuerySet:
         batch:
             Firestore batch writes
         """
-        transaction_or_batch = transaction if transaction else batch
+        transaction_or_batch = transaction if transaction is not None else batch
         DeleteQuery(self.model_cls, key, child=child).exec(
             transaction_or_batch)

--- a/src/fireo/queries/update_query.py
+++ b/src/fireo/queries/update_query.py
@@ -79,7 +79,7 @@ class UpdateQuery(BaseQuery):
     def _raw_exec(self, transaction_or_batch=None):
         """Update document in firestore and return the document"""
         ref = self._doc_ref()
-        if transaction_or_batch:
+        if transaction_or_batch is not None:
             transaction_or_batch.update(ref, self._parse_field())
             return ref
 
@@ -90,6 +90,6 @@ class UpdateQuery(BaseQuery):
 
     def exec(self, transaction_or_batch=None):
         """return modified instance of model"""
-        if transaction_or_batch:
+        if transaction_or_batch is not None:
             return self._raw_exec(transaction_or_batch)
         return query_wrapper.ModelWrapper.from_query_result(self.model, self._raw_exec())


### PR DESCRIPTION
We can not write `if batch` any more because __len__ is introduced in batch.
https://github.com/googleapis/python-firestore/blob/main/google/cloud/firestore_v1/base_batch.py#L45-L46

We have to check explicitly is it **None** or not.
And the same for transaction.

This fix unlock upgrade to 2.3.4.