### PR TITLE
Update new field fix

### DIFF
--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -434,8 +434,11 @@ class Model(metaclass=ModelMeta):
 
     def __setattr__(self, key, value):
         """Keep track which filed values are changed"""
-        if self._instance_modified:
-            self._field_changed.append(key)
-        else:
-            self._field_list.append(key)
+        self._field_changed.append(key)
+        self._field_list.append(key)
+        super(Model, self).__setattr__(key, value)
+
+    def _set_orig_attr(self, key, value):
+        """Keep track which filed values are changed"""
+        self._field_list.append(key)
         super(Model, self).__setattr__(key, value)

--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -434,7 +434,7 @@ class Model(metaclass=ModelMeta):
 
     def __setattr__(self, key, value):
         """Keep track which filed values are changed"""
-        if key in self._field_list or not self._instance_modified:
+        if self._instance_modified:
             self._field_changed.append(key)
         else:
             self._field_list.append(key)

--- a/src/fireo/queries/query_wrapper.py
+++ b/src/fireo/queries/query_wrapper.py
@@ -20,10 +20,6 @@ class ModelWrapper:
         else:
             return None
 
-        # instance values is changed according to firestore
-        # so mark it modified this will help later for figuring
-        # out the updated fields when need to update this document
-        setattr(model, '_instance_modified', True)
         for k, v in doc_dict.items():
             field = model._meta.get_field_by_column_name(k)
             # if missing field setting is set to "ignore" then
@@ -42,6 +38,11 @@ class ModelWrapper:
             else:
                 val = field.field_value(v)
             setattr(model, field.name, val)
+
+        # instance values is changed according to firestore
+        # so mark it modified this will help later for figuring
+        # out the updated fields when need to update this document
+        setattr(model, '_instance_modified', True)
 
         # If parent key is None but here is parent key from doc then set the parent for this model
         # This is case when you filter the documents parent key not auto set just set it

--- a/src/fireo/queries/query_wrapper.py
+++ b/src/fireo/queries/query_wrapper.py
@@ -20,6 +20,11 @@ class ModelWrapper:
         else:
             return None
 
+        # instance values is changed according to firestore
+        # so mark it modified this will help later for figuring
+        # out the updated fields when need to update this document
+        setattr(model, '_instance_modified', True)
+
         for k, v in doc_dict.items():
             field = model._meta.get_field_by_column_name(k)
             # if missing field setting is set to "ignore" then
@@ -37,12 +42,8 @@ class ModelWrapper:
                     val = None
             else:
                 val = field.field_value(v)
-            setattr(model, field.name, val)
-
-        # instance values is changed according to firestore
-        # so mark it modified this will help later for figuring
-        # out the updated fields when need to update this document
-        setattr(model, '_instance_modified', True)
+            # setattr(model, field.name, val)
+            model._set_orig_attr(field.name, val)
 
         # If parent key is None but here is parent key from doc then set the parent for this model
         # This is case when you filter the documents parent key not auto set just set it
@@ -57,7 +58,9 @@ class ModelWrapper:
             if model._meta.id is None:
                 model._meta.id = ('id', IDField())
                 
-            setattr(model, '_id', doc.id)
+            # setattr(model, '_id', doc.id)
+            model._set_orig_attr('_id', doc.id)
+
             # save the firestore reference doc so that further actions can be performed (i.e. collections())
             model._meta.set_reference_doc(doc.reference)
             # even though doc.reference currently points to self, there is no guarantee this will be true

--- a/src/tests/v149/test_update_new_field.py
+++ b/src/tests/v149/test_update_new_field.py
@@ -1,0 +1,32 @@
+from fireo.fields import TextField
+from fireo.models import Model
+
+
+class OldModel(Model):
+    class Meta:
+        collection_name = 'testcolletion'
+
+    first_name = TextField()
+    # old Model contains no field 'last_name'
+
+
+class NewModel(Model):
+    class Meta:
+        collection_name = 'testcolletion'
+
+    first_name = TextField()
+    # now we added 'last_name' field
+    last_name = TextField()
+
+
+def test_update_new_field():
+    old_instance = OldModel()
+    old_instance.first_name = 'First'
+    old_instance.save()
+
+    new_instance: NewModel = NewModel.collection.get(old_instance.key)
+    new_instance.last_name = 'Last'
+    new_instance.update()
+
+    got_instance = NewModel.collection.get(old_instance.key)
+    assert got_instance.last_name == 'Last'


### PR DESCRIPTION
In case if we added new field into a model it is not being read for first time.
New field did not pass through __setattr__ during a read from DB.
As result we are missing it in `self._field_list`.
So `.update()` ignore it for first time.

See my test which is failing in current version.