### PR TITLE
fix: adding Github Action python matrix support

### DIFF
--- a/.github/workflows/python-package-testing.yml
+++ b/.github/workflows/python-package-testing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-package-testing.yml
+++ b/.github/workflows/python-package-testing.yml
@@ -12,13 +12,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
We use this library in newer version of python. Would be helpful to see end-to-end tests in multiple python versions.