### PR TITLE
Refactor create query to fix meta.ignore_none_field = True

### DIFF
--- a/src/fireo/fields/base_field.py
+++ b/src/fireo/fields/base_field.py
@@ -1,4 +1,5 @@
 from fireo.fields.field_attribute import FieldAttribute
+from fireo.utils.types import DumpOptions
 
 
 class MetaField(type):
@@ -98,7 +99,7 @@ class Field(metaclass=MetaField):
         """
         return self.raw_attributes.get("column_name") or self.name
 
-    def get_value(self, val, ignore_required=False, ignore_default=False, changed_only=False):
+    def get_value(self, val, dump_options=DumpOptions()):
         """Get field value after validation
 
         Make validation and applying attribute function on it.
@@ -109,21 +110,18 @@ class Field(metaclass=MetaField):
         val : Any
             Field value
 
-        ignore_required : Bool
-            Ignore required fields or not mostly ignore when updating the document
-
-        ignore_default : Bool
-            Ignore default fields or not mostly ignore when updating the document
-
-        changed_only : Bool
-            Ignore fields which are not changed when updating the document.
-            Used in NestedModelField
+        dump_options : DumpOptions
+            Options for dumping to Firestore dictionary
 
         Returns
         -------
             DB value
         """
-        val = self.field_attribute.parse(val, ignore_required, ignore_default)
+        val = self.field_attribute.parse(
+            val,
+            dump_options.ignore_required,
+            dump_options.ignore_default,
+        )
         return self.db_value(val)
 
     def db_value(self, val):

--- a/src/fireo/fields/list_field.py
+++ b/src/fireo/fields/list_field.py
@@ -61,7 +61,7 @@ class ListField(Field):
                         val=item,
                         dump_options=replace(
                             dump_options,
-                            # changed_only used in update. Object nested in list cannot be updated partially
+                            # ignore_unchanged used in update. Object nested in list cannot be updated partially
                             ignore_unchanged=False,
                         )
                     ))

--- a/src/fireo/fields/nested_model_field.py
+++ b/src/fireo/fields/nested_model_field.py
@@ -2,6 +2,7 @@ from typing import Optional, TYPE_CHECKING
 
 from fireo.fields import errors
 from fireo.fields.base_field import Field
+from fireo.utils.types import DumpOptions
 
 if TYPE_CHECKING:
     from fireo.models import Model
@@ -38,10 +39,10 @@ class NestedModelField(Field):
         nested_model.populate_from_doc_dict(val, initial)
         return nested_model
 
-    def get_value(self, val: 'Optional[Model]', ignore_required=False, ignore_default=False, changed_only=False):
+    def get_value(self, val: 'Optional[Model]', dump_options=DumpOptions()):
         if val is not None:
-            val = val.to_db_dict(ignore_required, ignore_default, changed_only)
-        val = self.field_attribute.parse(val, ignore_required, ignore_default)
+            val = val.to_db_dict(dump_options)
+        val = self.field_attribute.parse(val, dump_options.ignore_required, dump_options.ignore_default)
         return self.db_value(val)
 
 

--- a/src/fireo/managers/managers.py
+++ b/src/fireo/managers/managers.py
@@ -166,7 +166,7 @@ class Manager:
         """
         return self.queryset.create(mutable_instance, transaction, batch, merge, no_return, **kwargs)
 
-    def _update(self, mutable_instance=None, transaction=None, batch=None, **kwargs):
+    def _update(self, mutable_instance, transaction=None, batch=None):
         """Update existing document in firestore collection
 
         Parameters
@@ -181,7 +181,7 @@ class Manager:
         batch:
             Firestore batch
         """
-        return self.queryset.update(mutable_instance, transaction, batch, **kwargs)
+        return self.queryset.update(mutable_instance, transaction, batch)
 
     def get(self, key, transaction=None):
         """Get document from firestore"""

--- a/src/fireo/managers/managers.py
+++ b/src/fireo/managers/managers.py
@@ -149,7 +149,7 @@ class Manager:
         """provide operations related to firestore"""
         return queries.QuerySet(self.model_cls)
 
-    def create(self, mutable_instance=None, transaction=None, batch=None, merge=None, no_return=False, **kwargs,):
+    def create(self, mutable_instance=None, transaction=None, batch=None, merge=None, no_return=False, **kwargs):
         """create new document in firestore collection
 
         Parameters
@@ -164,47 +164,7 @@ class Manager:
         batch:
             Firestore batch
         """
-        _EMPTY_DOC_EXCEPTION = "Empty document can not be save, Add at least one field value"
-        # Check if it empty document then don't save it
-        if not kwargs:
-            raise EmptyDocument(_EMPTY_DOC_EXCEPTION)
-
-        # Check if of the field value is not None
-        is_none_dict = True
-        for k, v in kwargs.items():
-            try:
-                f = self.model_cls._meta.get_field(k)
-                default_value = f.field_attribute.default
-                if v is not None or default_value is not None:
-                    is_none_dict = False
-                    break
-            except FieldNotFound:
-                if v is not None or default_value is not None:
-                    is_none_dict = False
-                    break
-
-        if is_none_dict:
-            raise EmptyDocument(_EMPTY_DOC_EXCEPTION)
-
-        # if mutable instance is none this mean user is creating document directly from manager
-        # For example User.collection.create(name="Azeem") in this case mutable instance will be None
-        field_list = kwargs
-
-        # If this model has custom IDField then
-        # Check if field list length is one(1) and field is IDField
-        # if this one field is IDField then this is also Empty Document
-        # which can not save
-        if self.model_cls._meta.id is not None:
-            if len(field_list) == 1:
-                # getting first key name from dict
-                first_key_name = next(iter(field_list))
-                id_name, _ = self.model_cls._meta.id
-
-                # Check first key is id
-                if first_key_name == id_name:
-                    raise EmptyDocument(_EMPTY_DOC_EXCEPTION)
-
-        return self.queryset.create(mutable_instance, transaction, batch, merge, no_return, **field_list)
+        return self.queryset.create(mutable_instance, transaction, batch, merge, no_return, **kwargs)
 
     def _update(self, mutable_instance=None, transaction=None, batch=None, **kwargs):
         """Update existing document in firestore collection

--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -260,7 +260,7 @@ class Model(metaclass=ModelMeta):
             )
             if (
                 (not ignore_unchanged or field_changed) and
-                (v is not None or not ignore_default_none or field_changed)
+                (not ignore_default_none or field_changed or v is not None)
             ):
                 field_list[f.name] = v
         return field_list
@@ -411,7 +411,7 @@ class Model(metaclass=ModelMeta):
             batch,
             merge,
             no_return,
-            **self._get_fields(ignore_unchanged=merge, ignore_default_none=True)
+            **self._get_fields(ignore_default_none=True)
         )
 
     def upsert(self, transaction=None, batch=None):
@@ -473,12 +473,9 @@ class Model(metaclass=ModelMeta):
             raise InvalidKey(
                 f'Invalid key to update model "{self.__class__.__name__}" ')
 
-        # Get the updated fields
-        updated_fields = self._get_fields(ignore_unchanged=True, ignore_default_none=True)
-
         # pass the model instance if want change in it after save, fetch etc operations
         # otherwise it will return new model instance
-        return self.__class__.collection._update(self, transaction=transaction, batch=batch, **updated_fields)
+        return self.__class__.collection._update(self, transaction=transaction, batch=batch)
 
     def __setattr__(self, key, value):
         """Keep track which filed values are changed"""

--- a/src/fireo/models/model_meta.py
+++ b/src/fireo/models/model_meta.py
@@ -142,7 +142,8 @@ class ModelMeta(type):
                 self.collection_name = utils.collection_name(cls.__name__)
                 self.abstract = False
                 self.missing_field = 'merge'
-                self.ignore_none_field = False
+                # If True, then ignore default None values. Changed field with None still will be saved.
+                self.ignore_none_field = True
                 self.to_lowercase = False
                 self._referenceDoc = None
 

--- a/src/fireo/queries/query_set.py
+++ b/src/fireo/queries/query_set.py
@@ -55,7 +55,7 @@ class QuerySet:
         transaction_or_batch = transaction if transaction is not None else batch
         return CreateQuery(self.model_cls, mutable_instance, no_return, **kwargs).exec(transaction_or_batch, merge)
 
-    def update(self, mutable_instance=None, transaction=None, batch=None, **kwargs):
+    def update(self, mutable_instance, transaction=None, batch=None):
         """Update existing document in firestore collection
 
         Parameters
@@ -81,7 +81,7 @@ class QuerySet:
             updated modified instance
         """
         transaction_or_batch = transaction if transaction is not None else batch
-        return UpdateQuery(self.model_cls, mutable_instance, **kwargs).exec(transaction_or_batch)
+        return UpdateQuery(self.model_cls, mutable_instance).exec(transaction_or_batch)
 
     def get(self, key, transaction=None):
         """Get document from firestore

--- a/src/fireo/queries/update_query.py
+++ b/src/fireo/queries/update_query.py
@@ -1,4 +1,3 @@
-from fireo.fields import DateTime
 from fireo.queries import query_wrapper
 from fireo.queries.base_query import BaseQuery
 from fireo.utils import utils
@@ -23,9 +22,9 @@ class UpdateQuery(BaseQuery):
     exec(transaction_or_batch):
         return modified instance of model
     """
-    def __init__(self, model_cls, mutable_instance=None, **kwargs):
+
+    def __init__(self, model_cls, mutable_instance):
         super().__init__(model_cls)
-        self.query = kwargs
         self.model = mutable_instance
         super().set_collection_path(key=mutable_instance.key)
 
@@ -49,18 +48,11 @@ class UpdateQuery(BaseQuery):
         in this case it will be like this
         `{full_name: "Azeem", age=25}`
         """
-        field_dict = {}
-        for f in self.model._meta.field_list.values():
-            if f.name in self.query:
-                v = f.get_value(
-                    self.query.get(f.name),
-                    dump_options=DumpOptions(
-                        ignore_required=True,
-                        ignore_default=True,
-                        ignore_unchanged=True,
-                    ),
-                )
-                field_dict[f.db_column_name] = v
+        field_dict = self.model.to_db_dict(dump_options=DumpOptions(
+            ignore_required=True,
+            ignore_default=True,
+            ignore_unchanged=True,
+        ))
 
         # Convert to dot notated fields update objects without replacing
         flat_field_dict = get_flat_dict(field_dict)

--- a/src/fireo/queries/update_query.py
+++ b/src/fireo/queries/update_query.py
@@ -2,6 +2,7 @@ from fireo.fields import DateTime
 from fireo.queries import query_wrapper
 from fireo.queries.base_query import BaseQuery
 from fireo.utils import utils
+from fireo.utils.types import DumpOptions
 from fireo.utils.utils import get_flat_dict
 
 
@@ -53,9 +54,11 @@ class UpdateQuery(BaseQuery):
             if f.name in self.query:
                 v = f.get_value(
                     self.query.get(f.name),
-                    ignore_required=True,
-                    ignore_default=True,
-                    changed_only=True,
+                    dump_options=DumpOptions(
+                        ignore_required=True,
+                        ignore_default=True,
+                        ignore_unchanged=True,
+                    ),
                 )
                 field_dict[f.db_column_name] = v
 

--- a/src/fireo/utils/types.py
+++ b/src/fireo/utils/types.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DumpOptions:
+    """Options for dumping a model to a FireStore dictionary."""
+
+    ignore_required: bool = False
+    """Ignore required fields or not mostly ignore when updating the document."""
+
+    ignore_default: bool = False
+    """Ignore default fields or not mostly ignore when updating the document."""
+
+    ignore_default_none: bool = False
+    """Ignore default None values. Mostly used during creation of document.
+    Used in NestedModelField."""
+
+    ignore_unchanged: bool = False
+    """Ignore fields which are not changed when updating the document.
+    Used in NestedModelField."""

--- a/src/tests/older_versions/v12/test_fix_update_with_none_value.py
+++ b/src/tests/older_versions/v12/test_fix_update_with_none_value.py
@@ -4,6 +4,7 @@ from fireo.models import Model
 from fireo.fields.text_field import TextField
 from fireo.fields.number_field import NumberField
 from fireo.fields.errors import NumberRangeError
+from fireo.models.errors import ModelSerializingWrappedError
 
 
 def test_fix_issue_48():
@@ -37,5 +38,7 @@ def test_fix_issue_48():
     assert person.type == 1
 
     person.type = 3
-    with pytest.raises(NumberRangeError):
+    with pytest.raises(ModelSerializingWrappedError) as e:
         person.update()
+
+    assert isinstance(e.value.original_error, NumberRangeError)

--- a/src/tests/v1.8.0/test_ignore_none_field.py
+++ b/src/tests/v1.8.0/test_ignore_none_field.py
@@ -1,0 +1,76 @@
+from fireo import db
+from fireo.fields import NestedModelField, TextField
+from fireo.models import Model
+
+
+class NestedIgnoreNoneModel(Model):
+    class Meta:
+        ignore_none_field = True
+
+    field1 = TextField()
+    field2 = TextField(default='default')
+
+
+class IgnoreNoneModel(Model):
+    class Meta:
+        ignore_none_field = True
+
+    field1 = TextField()
+    field2 = TextField(default='default')
+    nested = NestedModelField(NestedIgnoreNoneModel)
+
+
+def test_ignore_default_none_on_create():
+    model = IgnoreNoneModel().save()
+
+    doc_dict = db.conn.collection(IgnoreNoneModel.collection_name).document(model.id).get().to_dict()
+
+    assert doc_dict == {'field2': 'default', 'nested': {'field2': 'default'}}
+
+
+def test_not_ignore_not_default_none_on_update():
+    model = IgnoreNoneModel().save()
+    model.nested.field1 = None
+    model.save()
+
+    doc_dict = db.conn.collection(IgnoreNoneModel.collection_name).document(model.id).get().to_dict()
+
+    assert doc_dict == {
+        'field2': 'default',
+        'nested': {
+            'field1': None,
+            'field2': 'default',
+        },
+    }
+
+
+class NestedNotIgnoreNoneModel(Model):
+    class Meta:
+        ignore_none_field = False
+
+    field1 = TextField()
+    field2 = TextField(default='default')
+
+
+class NotIgnoreNoneModel(Model):
+    class Meta:
+        ignore_none_field = False
+
+    field1 = TextField()
+    field2 = TextField(default='default')
+    nested = NestedModelField(NestedIgnoreNoneModel)
+
+
+def test_not_ignore_default_none_on_create():
+    model = NotIgnoreNoneModel().save()
+
+    doc_dict = db.conn.collection(NotIgnoreNoneModel.collection_name).document(model.id).get().to_dict()
+
+    assert doc_dict == {
+        'field1': None,
+        'field2': 'default',
+        'nested': {
+            'field1': None,
+            'field2': 'default',
+        }
+    }


### PR DESCRIPTION
`meta.ignore_none_field` now means: Ignore default None values but save None if it was set explicitly:
```
MyModel().save()  # ignore Nones
```

```
MyModel(my_field=None).save()   # ignore Nones but not for my_field
```

```
MyModel(my_field=None).update(key)  # partial update with my_field is None
```