### PR TITLE
Feature/allow model meta fields inheritance and more

### DIFF
--- a/src/fireo/fields/base_field.py
+++ b/src/fireo/fields/base_field.py
@@ -1,5 +1,5 @@
 from fireo.fields.field_attribute import FieldAttribute
-from fireo.utils.types import DumpOptions
+from fireo.utils.types import DumpOptions, LoadOptions
 
 
 class MetaField(type):
@@ -159,7 +159,7 @@ class Field(metaclass=MetaField):
                 return val.lower() if type(val) is str else val
         return val
 
-    def field_value(self, val, model, initial):
+    def field_value(self, val, load_options=LoadOptions()):
         """ How this field represent value that is coming from firestore
 
         Value can be modified after getting value from firestore

--- a/src/fireo/fields/field_attribute.py
+++ b/src/fireo/fields/field_attribute.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 from fireo.fields.errors import *
 
 
@@ -20,7 +22,10 @@ class FieldAttribute:
         In firestore this fields will be store as **full_name**
 
     default:
-        if no value is define then default value is set for field
+        if no value is defined then default value is set for field
+
+    default_factory:
+        if no value is defined then default_factory is called to value set for field
 
     required:
         Required field if no value or default set raise an Error
@@ -56,7 +61,7 @@ class FieldAttribute:
     AttributeMethodNotDefined:
         if any custom field not define the method for `allowed_attributes`
     """
-    allowed_attributes = ['default', 'required', 'column_name', 'validator', 'validator_kwargs']
+    allowed_attributes = ['default', 'default_factory', 'required', 'column_name', 'validator', 'validator_kwargs']
 
     def __init__(self, field, attributes):
         self.field = field
@@ -78,8 +83,12 @@ class FieldAttribute:
                 return value
 
             # check default value if set for field
-            if self.default is not None and value is None and not ignore_default:
-                value = self.default
+            if value is None and not ignore_default:
+                if self.default is not None:
+                    value = copy(self.default)
+
+                elif self.default_factory is not None:
+                    value = self.default_factory()
 
             # check this field is required or not
             if self.required and value is None and not ignore_required:
@@ -199,6 +208,11 @@ class FieldAttribute:
     def default(self):
         """if no value is define then default value is set for field"""
         return self.attributes.get('default')
+
+    @property
+    def default_factory(self):
+        """if no value is define then default value is set for field"""
+        return self.attributes.get('default_factory')
 
     @property
     def required(self):

--- a/src/fireo/fields/id_field.py
+++ b/src/fireo/fields/id_field.py
@@ -19,7 +19,16 @@ class IDField(Field):
 
         # After save id will be saved in `user_id`
         print(self.user_id)  # custom_doc_id
+
+    Attributes
+    ----------
+        include_in_document: bool = False (default) If true then id will be included in FireStore document
     """
+
+    def __init__(self, *args, include_in_document=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.include_in_document = include_in_document
+
     def contribute_to_model(self, model_cls, name):
         self.name = name
         setattr(model_cls, name, None)

--- a/src/fireo/fields/id_field.py
+++ b/src/fireo/fields/id_field.py
@@ -27,9 +27,8 @@ class IDField(Field):
         include_in_document: bool = False (default) If true then id will be included in FireStore document
     """
 
-    def __init__(self, *args, include_in_document=False, **kwargs):
-        # super().__init__(*args, **kwargs)
-        super().__init__(*args, **kwargs, default_factory=_auto_id)
+    def __init__(self, *args, include_in_document=False, default_factory=_auto_id, **kwargs):
+        super().__init__(*args, **kwargs, default_factory=default_factory)
         self.include_in_document = include_in_document
 
     def contribute_to_model(self, model_cls, name):

--- a/src/fireo/fields/id_field.py
+++ b/src/fireo/fields/id_field.py
@@ -1,3 +1,5 @@
+from google.cloud.firestore_v1.base_collection import _auto_id
+
 from fireo.fields.base_field import Field
 
 
@@ -26,7 +28,8 @@ class IDField(Field):
     """
 
     def __init__(self, *args, include_in_document=False, **kwargs):
-        super().__init__(*args, **kwargs)
+        # super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs, default_factory=_auto_id)
         self.include_in_document = include_in_document
 
     def contribute_to_model(self, model_cls, name):

--- a/src/fireo/fields/list_field.py
+++ b/src/fireo/fields/list_field.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 from google.cloud.firestore_v1 import ArrayRemove, ArrayUnion
 
 from fireo.fields import errors, Field, IDField
-from fireo.utils.types import DumpOptions
+from fireo.utils.types import DumpOptions, LoadOptions
 
 
 class ListField(Field):
@@ -80,12 +80,18 @@ class ListField(Field):
 
         return val
 
-    def field_value(self, val: Optional[List[Any]], model, initial) -> Optional[List[Any]]:
-        parsed = super().field_value(val, model, initial)
+    def field_value(self, val: Optional[List[Any]], load_options=LoadOptions()) -> Optional[List[Any]]:
+        parsed = super().field_value(val, load_options)
         nested_field: Optional[Field] = self.raw_attributes.get('nested_field')
 
         if parsed is not None and nested_field is not None:
-            parsed = [nested_field.field_value(item, model, initial) for item in parsed]
+            parsed = [
+                nested_field.field_value(item, replace(
+                    load_options,
+                    merge=False,  # merge is not supported for list items
+                ))
+                for item in parsed
+            ]
 
         return parsed
 

--- a/src/fireo/fields/reference_field.py
+++ b/src/fireo/fields/reference_field.py
@@ -5,6 +5,8 @@ from fireo.queries.query_wrapper import ReferenceDocLoader
 from fireo.utils import utils
 from google.cloud import firestore
 
+from fireo.utils.types import LoadOptions
+
 
 class ReferenceField(Field):
     """Reference of other model
@@ -56,13 +58,13 @@ class ReferenceField(Field):
         self.on_load = None
 
     # Override method
-    def field_value(self, val, model, initial):
+    def field_value(self, val, load_options=LoadOptions()):
         ref = self.field_attribute.parse(val)
 
         if not ref:
             return None
 
-        ref_doc = ReferenceDocLoader(model, self, ref)
+        ref_doc = ReferenceDocLoader(load_options.model, self, ref)
 
         if self.auto_load:
             return ref_doc.get()

--- a/src/fireo/fields/text_field.py
+++ b/src/fireo/fields/text_field.py
@@ -2,6 +2,8 @@ from fireo.fields import errors
 from fireo.fields.base_field import Field
 import re
 
+from fireo.utils.types import LoadOptions
+
 
 class TextField(Field):
     """Text field for Models
@@ -59,7 +61,7 @@ class TextField(Field):
                                       f'got {type(val)}')
 
     # override method
-    def field_value(self, val, model, initial):
+    def field_value(self, val, load_options=LoadOptions()):
 
         # check if val is None then there is no need to run these functions
         # just return back the None value

--- a/src/fireo/managers/managers.py
+++ b/src/fireo/managers/managers.py
@@ -164,9 +164,10 @@ class Manager:
         batch:
             Firestore batch
         """
-        return self.queryset.create(mutable_instance, transaction, batch, merge, no_return, **{
-            'parent': self._parent_key, **kwargs
-        })
+        if self._parent_key:
+            kwargs['parent'] = self._parent_key
+
+        return self.queryset.create(mutable_instance, transaction, batch, merge, no_return, **kwargs)
 
     def _update(self, mutable_instance, transaction=None, batch=None):
         """Update existing document in firestore collection

--- a/src/fireo/managers/managers.py
+++ b/src/fireo/managers/managers.py
@@ -192,6 +192,10 @@ class Manager:
         for key in key_list:
             yield self.queryset.get(key)
 
+    def _refresh(self, mutable_instance, transaction=None):
+        """Refresh document from firestore"""
+        return self.queryset.refresh(mutable_instance, transaction)
+
     def parent(self, key):
         """Parent collection"""
         self._parent_key = key

--- a/src/fireo/managers/managers.py
+++ b/src/fireo/managers/managers.py
@@ -164,7 +164,9 @@ class Manager:
         batch:
             Firestore batch
         """
-        return self.queryset.create(mutable_instance, transaction, batch, merge, no_return, **kwargs)
+        return self.queryset.create(mutable_instance, transaction, batch, merge, no_return, **{
+            'parent': self._parent_key, **kwargs
+        })
 
     def _update(self, mutable_instance, transaction=None, batch=None):
         """Update existing document in firestore collection

--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -129,6 +129,9 @@ class Model(metaclass=ModelMeta):
     _create_time = None
     _update_time = None
 
+    class Meta:
+        abstract = True
+
     def __init__(self, *args, **kwargs):
         assert not args, 'You must use keyword arguments when instantiating a model'
         # check this is not abstract model otherwise stop creating instance of this model

--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -186,8 +186,9 @@ class Model(metaclass=ModelMeta):
             field: Field  # type: ignore
 
             if isinstance(field, IDField):
-                # do not include ID field to dict for firestore
-                continue
+                if not field.include_in_document:
+                    # do not include ID field to dict for firestore unless it is explicitly set
+                    continue
 
             field_changed = field.name in self._field_changed
             if dump_options.ignore_unchanged and not field_changed:

--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -223,7 +223,9 @@ class Model(metaclass=ModelMeta):
 
         new_extra_fields_names = set(doc_dict) - set(self._meta.field_list)
         if new_extra_fields_names and not by_column_name:
-            raise NotImplementedError("Can't populate model from dict with unknown fields")
+            raise NotImplementedError(
+                f"Can't populate model from dict with unknown fields: {new_extra_fields_names}"
+            )
 
         new_extra_fields = [
             self._meta.get_field_by_column_name(field_name)

--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -560,12 +560,14 @@ class Model(metaclass=ModelMeta):
             return True
 
         field = self._meta.field_list[field_name]
-        if type(field) in (
-            fields.MapField,
-            fields.ListField,
-            fields.NestedModelField,
-        ):
-            # Is unchanged check is not implemented for these fields types yet
-            return True
+        value = getattr(self, field_name)
+        if value is not None:
+            if type(field) in (
+                fields.MapField,
+                fields.ListField,
+                fields.NestedModelField,
+            ):
+                # Is unchanged check is not implemented for these fields types yet
+                return True
 
         return False

--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -133,8 +133,16 @@ class Model(metaclass=ModelMeta):
     class Meta:
         abstract = True
 
-    def __init__(self, *args, **kwargs):
-        assert not args, 'You must use keyword arguments when instantiating a model'
+    def __init__(self, *args, parent: str = "", **kwargs):
+        self.parent = parent
+        if args:
+            raise AttributeError('You must use keyword arguments when instantiating a model')
+        unexpected_kwargs = set(kwargs) - set(self._meta.field_list)
+        if unexpected_kwargs:
+            raise AttributeError(
+                'You passed in unknown keyword arguments: {}'.format(', '.join(unexpected_kwargs))
+            )
+
         # check this is not abstract model otherwise stop creating instance of this model
         if self._meta.abstract:
             raise AbstractNotInstantiate(

--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -1,6 +1,6 @@
 import warnings
 
-from fireo import fields
+from fireo import db, fields
 from fireo.managers.managers import Manager
 from fireo.models.errors import AbstractNotInstantiate, ModelSerializingWrappedError
 from fireo.models.model_meta import ModelMeta
@@ -351,8 +351,7 @@ class Model(metaclass=ModelMeta):
 
     def list_subcollections(self):
         """return a list of any subcollections of the doc"""
-        if self._meta._referenceDoc is not None:
-            return [c.id for c in self._meta._referenceDoc.collections()]
+        return [c.id for c in self.document_reference().collections()]
 
     def save(self, transaction=None, batch=None, merge=None, no_return=False):
         """Save Model in firestore collection
@@ -464,3 +463,14 @@ class Model(metaclass=ModelMeta):
     def _set_orig_attr(self, key, value):
         """Keep track which filed values are changed"""
         super(Model, self).__setattr__(key, value)
+
+    @property
+    def document_path(self):
+        doc_path = self.collection_name + '/' + self._id
+        if self.parent:
+            doc_path = self.parent + '/' + doc_path
+
+        return doc_path
+
+    def document_reference(self):
+        return db.conn.document(self.document_path)

--- a/src/fireo/models/model_meta.py
+++ b/src/fireo/models/model_meta.py
@@ -91,8 +91,6 @@ class ModelMeta(type):
                                            f'model "{b.__name__}"')
                 continue
             for name, field in b._meta.field_list.items():
-                # Ignore the id field
-                if isinstance(field, fields.IDField): continue
                 field.contribute_to_model(cls, name)
 
         if not cls._meta.abstract and cls._meta.id is None:

--- a/src/fireo/models/model_meta.py
+++ b/src/fireo/models/model_meta.py
@@ -244,6 +244,7 @@ class Meta:
         # Convert Model class into collection name
         # change it to lower case and snake case
         # e.g UserCollection into user_collection
+        self._collection_name = None
         self.abstract = False
         self.model_cls = model_cls
         self.default_manager_cls = default_manager_cls
@@ -262,7 +263,14 @@ class Meta:
 
     @property
     def collection_name(self):
-        return self.collection_name_generator(self.model_cls.__name__)
+        if self._collection_name is None:
+            return self.collection_name_generator(self.model_cls.__name__)
+
+        return self._collection_name
+
+    @collection_name.setter
+    def collection_name(self, value):
+        self._collection_name = value
 
     @classmethod
     def from_parent_meta(cls, model_cls, parent_meta: 'Meta') -> 'Meta':

--- a/src/fireo/models/model_meta.py
+++ b/src/fireo/models/model_meta.py
@@ -144,7 +144,6 @@ class ModelMeta(type):
                 self.missing_field = 'merge'
                 self.ignore_none_field = False
                 self.to_lowercase = False
-                self._referenceDoc = None
 
             # Attached manager to model class
             # later on manager can be accessible via class `collection` attribute
@@ -248,10 +247,6 @@ class ModelMeta(type):
                     return None
                 if self.missing_field == 'raise_error':
                     raise FieldNotFound(f'Field "{name}" not found in model "{cls.__name__}"')
-
-            def set_reference_doc(self, referenceDoc):
-                """save the firestore reference doc for further processing"""
-                self._referenceDoc = referenceDoc
 
             def set_user_defined_meta(self, user_meta):
                 """Set user defined meta attributes for model

--- a/src/fireo/models/model_meta.py
+++ b/src/fireo/models/model_meta.py
@@ -236,6 +236,7 @@ class Meta:
         ignore_none_field=True,
         to_lowercase=False,
         column_name_generator=None,
+        collection_name_generator=utils.collection_name,
     ):
         self.id = None  # Model id if user specify otherwise just None will generate late by firestore automatically
         self.field_list = {}  # Hold all the model fields
@@ -243,7 +244,6 @@ class Meta:
         # Convert Model class into collection name
         # change it to lower case and snake case
         # e.g UserCollection into user_collection
-        self.collection_name = utils.collection_name(model_cls.__name__)
         self.abstract = False
         self.model_cls = model_cls
         self.default_manager_cls = default_manager_cls
@@ -251,6 +251,7 @@ class Meta:
         self.ignore_none_field = ignore_none_field
         self.to_lowercase = to_lowercase
         self.column_name_generator = column_name_generator
+        self.collection_name_generator = collection_name_generator
 
         # Attached manager to model class
         # later on manager can be accessible via class `collection` attribute
@@ -259,15 +260,20 @@ class Meta:
             manager = self.default_manager_cls()
             manager.contribute_to_model(model_cls)
 
+    @property
+    def collection_name(self):
+        return self.collection_name_generator(self.model_cls.__name__)
+
     @classmethod
     def from_parent_meta(cls, model_cls, parent_meta: 'Meta') -> 'Meta':
         return cls(
-            model_cls,
+            model_cls=model_cls,
             default_manager_cls=parent_meta.default_manager_cls,
             missing_field=parent_meta.missing_field,
             ignore_none_field=parent_meta.ignore_none_field,
             to_lowercase=parent_meta.to_lowercase,
             column_name_generator=parent_meta.column_name_generator,
+            collection_name_generator=parent_meta.collection_name_generator,
         )
 
     def add_model_id(self, field):
@@ -403,6 +409,7 @@ class Meta:
                 'ignore_none_field',
                 'default_manager_cls',
                 'column_name_generator',
+                'collection_name_generator',
             ]
 
             # check if name is supported by meta and name is not

--- a/src/fireo/models/model_meta.py
+++ b/src/fireo/models/model_meta.py
@@ -85,11 +85,8 @@ class ModelMeta(type):
             if not hasattr(b, '_meta'):
                 continue
             if not b._meta.abstract:
-                from fireo.models import Model
-                if b != Model:
-                    raise NonAbstractModel(f'Model "{cls.__name__}" can not inherit from non abstract '
-                                           f'model "{b.__name__}"')
-                continue
+                raise NonAbstractModel(f'Model "{cls.__name__}" can not inherit from non abstract '
+                                       f'model "{b.__name__}"')
             for name, field in b._meta.field_list.items():
                 field.contribute_to_model(cls, name)
 

--- a/src/fireo/queries/create_query.py
+++ b/src/fireo/queries/create_query.py
@@ -110,7 +110,7 @@ class CreateQuery(BaseQuery):
         # This is important to reset, so we can
         # find next time which fields are changed
         # when we are going to update it
-        self.model._field_changed = []
+        self.model._field_changed = set()
 
         # If no_return is True then return nothing otherwise 
         # return object instance issue #126

--- a/src/fireo/queries/create_query.py
+++ b/src/fireo/queries/create_query.py
@@ -96,9 +96,11 @@ class CreateQuery(BaseQuery):
         if transaction_or_batch is not None:
             if merge:
                 transaction_or_batch.set(
-                    ref, self._parse_field(), merge=merge)
+                    ref, self._parse_field(ignore_unchanged=True), merge=merge)
             else:
                 transaction_or_batch.set(ref, self._parse_field())
+
+            self.model._id = ref.id
             return ref
 
         if merge:

--- a/src/fireo/queries/create_query.py
+++ b/src/fireo/queries/create_query.py
@@ -34,14 +34,7 @@ class CreateQuery(BaseQuery):
             super().set_collection_path(key=mutable_instance.key)
         else:
             self.model = model_cls()
-
-            # Suppose user is defined the id for model
-            # let name id **id**
-            id_field = 'id'
-
-            # Check user provide any custom name for id
-            if model_cls._meta.id is not None:
-                id_field, _ = model_cls._meta.id
+            id_field, _ = model_cls._meta.id
 
             # _id setter in model check either user defined
             # any id or not in model

--- a/src/fireo/queries/create_query.py
+++ b/src/fireo/queries/create_query.py
@@ -22,27 +22,21 @@ class CreateQuery(BaseQuery):
         return modified or new instance of model
     """
 
-    def __init__(self, model_cls, mutable_instance=None, no_return=False, parent=None, **kwargs):
+    def __init__(self, model_cls, mutable_instance=None, no_return=False, **kwargs):
         super().__init__(model_cls)
         self.no_return = no_return
         # If this is called from manager or mutable model is
         # not provided then this `model` will be a class not instance
         # then create new instance from this model class
         # otherwise set mutable instance to self.model
-        if mutable_instance:
-            self.model = mutable_instance
-            super().set_collection_path(key=mutable_instance.key)
-        else:
+        self.model = mutable_instance
+        if self.model is None:
             self.model = model_cls()
-            id_field, _ = model_cls._meta.id
 
-            # _id setter in model check either user defined
-            # any id or not in model
-            setattr(self.model, '_id', kwargs.get(id_field))
-            # Check if there is any parent
-            if parent:
-                self.model.parent = parent
-                super().set_collection_path(path=parent)
+        if "parent" in kwargs:
+            self.model.parent = kwargs["parent"]
+
+        super().set_collection_path(key=self.model.key)
 
         for k, v in kwargs.items():
             setattr(self.model, k, v)
@@ -91,21 +85,15 @@ class CreateQuery(BaseQuery):
 
     def _raw_exec(self, transaction_or_batch=None, merge=None):
         """save model into firestore and return the document"""
+        merge = bool(merge)
         ref = self._doc_ref()
+        self.model._id = ref.id
+        values = self._parse_field(ignore_unchanged=merge)
         if transaction_or_batch is not None:
-            if merge:
-                transaction_or_batch.set(
-                    ref, self._parse_field(ignore_unchanged=True), merge=merge)
-            else:
-                transaction_or_batch.set(ref, self._parse_field())
-
-            self.model._id = ref.id
+            transaction_or_batch.set(ref, values, merge=merge)
             return ref
 
-        if merge:
-            ref.set(self._parse_field(ignore_unchanged=True), merge=merge)
-        else:
-            ref.set(self._parse_field())
+        ref.set(values, merge=merge)
 
         # Reset the field changed list
         # This is important to reset, so we can

--- a/src/fireo/queries/create_query.py
+++ b/src/fireo/queries/create_query.py
@@ -22,7 +22,7 @@ class CreateQuery(BaseQuery):
         return modified or new instance of model
     """
 
-    def __init__(self, model_cls, mutable_instance=None, no_return=False, **kwargs):
+    def __init__(self, model_cls, mutable_instance=None, no_return=False, parent=None, **kwargs):
         super().__init__(model_cls)
         self.no_return = no_return
         # If this is called from manager or mutable model is
@@ -40,7 +40,6 @@ class CreateQuery(BaseQuery):
             # any id or not in model
             setattr(self.model, '_id', kwargs.get(id_field))
             # Check if there is any parent
-            parent = kwargs.get('parent')
             if parent:
                 self.model.parent = parent
                 super().set_collection_path(path=parent)

--- a/src/fireo/queries/query_set.py
+++ b/src/fireo/queries/query_set.py
@@ -27,7 +27,7 @@ class QuerySet:
     def __init__(self, model_cls):
         self.model_cls = model_cls
 
-    def create(self, mutable_instance=None, transaction=None, batch=None, merge=None, no_return=False, parent=None, **kwargs):
+    def create(self, mutable_instance=None, transaction=None, batch=None, merge=None, no_return=False, **kwargs):
         """Create new document in firestore collection
 
         Parameters
@@ -54,7 +54,7 @@ class QuerySet:
             modified instance or new instance if no mutable instance provided
         """
         transaction_or_batch = transaction if transaction is not None else batch
-        return CreateQuery(self.model_cls, mutable_instance, no_return, parent, **kwargs).exec(transaction_or_batch, merge)
+        return CreateQuery(self.model_cls, mutable_instance, no_return, **kwargs).exec(transaction_or_batch, merge)
 
     def update(self, mutable_instance, transaction=None, batch=None):
         """Update existing document in firestore collection

--- a/src/fireo/queries/query_set.py
+++ b/src/fireo/queries/query_set.py
@@ -27,7 +27,7 @@ class QuerySet:
     def __init__(self, model_cls):
         self.model_cls = model_cls
 
-    def create(self, mutable_instance=None, transaction=None, batch=None, merge=None, no_return=False, **kwargs):
+    def create(self, mutable_instance=None, transaction=None, batch=None, merge=None, no_return=False, parent=None, **kwargs):
         """Create new document in firestore collection
 
         Parameters
@@ -54,7 +54,7 @@ class QuerySet:
             modified instance or new instance if no mutable instance provided
         """
         transaction_or_batch = transaction if transaction is not None else batch
-        return CreateQuery(self.model_cls, mutable_instance, no_return, **kwargs).exec(transaction_or_batch, merge)
+        return CreateQuery(self.model_cls, mutable_instance, no_return, parent, **kwargs).exec(transaction_or_batch, merge)
 
     def update(self, mutable_instance, transaction=None, batch=None):
         """Update existing document in firestore collection

--- a/src/fireo/queries/query_set.py
+++ b/src/fireo/queries/query_set.py
@@ -2,6 +2,7 @@ from fireo.queries.delete_query import DeleteQuery
 from fireo.queries.filter_query import FilterQuery
 from fireo.queries.get_query import GetQuery
 from fireo.queries.create_query import CreateQuery
+from fireo.queries.refresh_query import RefreshQuery
 from fireo.queries.update_query import UpdateQuery
 
 
@@ -100,6 +101,25 @@ class QuerySet:
             wrap query result into model instance
         """
         return GetQuery(self.model_cls, key).exec(transaction)
+
+    def refresh(self, mutable_instance, transaction=None):
+        """Refresh document from firestore
+
+        Parameters
+        ----------
+        mutable_instance: Model instance
+            Make changes in existing model instance After performing firestore action modified this instance
+            adding things init like id, key etc
+
+        transaction:
+            Firestore transaction
+
+        Returns
+        -------
+        Model instance:
+            wrap query result into model instance
+        """
+        return RefreshQuery(self.model_cls, mutable_instance).exec(transaction)
 
     def filter(self, parent=None, *args, **kwargs):
         """Filter document from firestore

--- a/src/fireo/queries/query_wrapper.py
+++ b/src/fireo/queries/query_wrapper.py
@@ -15,7 +15,7 @@ class ModelWrapper:
         if not doc_dict:
             return None
 
-        model.populate_from_doc_dict(doc_dict, True)
+        model.populate_from_doc_dict(doc_dict, stored=True, by_column_name=True)
 
         # If parent key is None but here is parent key from doc then set the parent for this model
         # This is case when you filter the documents parent key not auto set just set it

--- a/src/fireo/queries/query_wrapper.py
+++ b/src/fireo/queries/query_wrapper.py
@@ -31,8 +31,6 @@ class ModelWrapper:
         # setattr(model, '_id', doc.id)
         model._set_orig_attr('_id', doc.id)
 
-        # save the firestore reference doc so that further actions can be performed (i.e. collections())
-        model._meta.set_reference_doc(doc.reference)
         # even though doc.reference currently points to self, there is no guarantee this will be true
         # in the future, therefore we should store the create time and update time separate.
         model._create_time = doc.create_time

--- a/src/fireo/queries/query_wrapper.py
+++ b/src/fireo/queries/query_wrapper.py
@@ -22,12 +22,6 @@ class ModelWrapper:
         if not model.parent and parent_key is not None:
             model.parent = parent_key
 
-        # When getting document attach the IDField if there is no user specify
-        # it will prevent to generate new id everytime when document save
-        # For more information see issue #45 https://github.com/octabytes/FireO/issues/45
-        if model._meta.id is None:
-            model._meta.id = ('id', IDField())
-
         # setattr(model, '_id', doc.id)
         model._set_orig_attr('_id', doc.id)
 

--- a/src/fireo/queries/refresh_query.py
+++ b/src/fireo/queries/refresh_query.py
@@ -1,0 +1,56 @@
+from typing import TYPE_CHECKING
+
+from fireo.queries import query_wrapper
+from fireo.queries.base_query import BaseQuery
+from fireo.utils import utils
+
+if TYPE_CHECKING:
+    from fireo.models import Model
+
+
+class RefreshQuery(BaseQuery):
+    """Refresh model from firestore
+
+    Refresh model from firestore using Managers
+
+    Examples
+    --------
+    .. code-block:: python
+        class User(Mode):
+            name = TextField()
+            age = NumberField()
+
+        u = User(name="Azeem", age=26)
+        u.save()
+
+        User(age=27).update(u.key)
+        u.refresh()
+
+        # Getting model
+        user = User.collection.get(u.key)
+        print(user.name)  # Azeem
+        print(user.age)  # 27
+
+    Methods
+    -------
+    _raw_exec():
+        private method to get documents from firestore
+
+    exec():
+        Get document from firestore and wrap them into model
+    """
+
+    def __init__(self, model_class, mutable_model: 'Model'):
+        super().__init__(model_class)
+        super().set_collection_path(key=mutable_model.key)
+        self.model = mutable_model
+        self.id = utils.get_id(mutable_model.key)
+
+    def _raw_exec(self, transaction=None):
+        """Get firestore reference and then get document based on id"""
+        ref = self.get_ref().document(self.id)
+        return ref.get(transaction=transaction)
+
+    def exec(self, transaction=None):
+        """Wrap the query result into model instance"""
+        return query_wrapper.ModelWrapper.from_query_result(self.model, self._raw_exec(transaction))

--- a/src/fireo/queries/update_query.py
+++ b/src/fireo/queries/update_query.py
@@ -62,6 +62,7 @@ class UpdateQuery(BaseQuery):
     def _raw_exec(self, transaction_or_batch=None):
         """Update document in firestore and return the document"""
         ref = self._doc_ref()
+        self.model._id = ref.id  #
         if transaction_or_batch is not None:
             transaction_or_batch.update(ref, self._parse_field())
             return ref

--- a/src/fireo/utils/types.py
+++ b/src/fireo/utils/types.py
@@ -1,4 +1,8 @@
 from dataclasses import dataclass
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fireo.models import Model
 
 
 @dataclass(frozen=True)
@@ -18,3 +22,20 @@ class DumpOptions:
     ignore_unchanged: bool = False
     """Ignore fields which are not changed when updating the document.
     Used in NestedModelField."""
+
+
+@dataclass(frozen=True)
+class LoadOptions:
+    """Options for loading a FireStore dictionary to a model."""
+
+    model: 'Optional[Model]' = None
+    """Model instance that contains that field."""
+
+    stored: bool = False
+    """Is the field stored in FireStore or not."""
+
+    merge: bool = False
+    """Merge data with existing data or not. Mostly used in NestedModelField."""
+
+    by_column_name: bool = False
+    """Load data by column name or not. Mostly used in NestedModelField."""

--- a/src/fireo/utils/utils.py
+++ b/src/fireo/utils/utils.py
@@ -77,12 +77,7 @@ def get_flat_dict(dict_, prefix: str = None):
             flat_dict[key] = value
     return flat_dict
 
-
-def generateKeyFromId(model, id):
-    return model.collection_name + "/" + id
-
-
-def isKey(str):
+def is_key(str):
     return "/" in str
 
 

--- a/src/tests/older_versions/v010/custom_field_test.py
+++ b/src/tests/older_versions/v010/custom_field_test.py
@@ -1,5 +1,6 @@
 from fireo.fields import Field
 from fireo.models import Model
+from fireo.utils.types import LoadOptions
 
 
 class WeekDays(Field):
@@ -41,7 +42,7 @@ class WeekDays3(Field):
     def db_value(self, val):
         return self.days[val]
 
-    def field_value(self, val, model, initial):
+    def field_value(self, val, load_options=LoadOptions()):
         return self.days.index(val)
 
 

--- a/src/tests/older_versions/v010/simple_id_key_test.py
+++ b/src/tests/older_versions/v010/simple_id_key_test.py
@@ -87,9 +87,10 @@ def test_without_id_field_but_giving_id():
     e1.name = 'test_without_id_but_give_some_id'
     e1.save()
 
-    assert e1.id != 'test_without_id_but_giving_id'
+    # "id" is a default name for document id
+    assert e1.id == 'test_without_id_but_giving_id'
 
     e2 = EmployeeIDField.collection.get(e1.key)
-    assert e2.id != 'test_without_id_but_giving_id'
+    assert e2.id == 'test_without_id_but_giving_id'
     assert e1.name == e2.name
     assert e1.key == e2.key

--- a/src/tests/older_versions/v030/test_deep_nested.py
+++ b/src/tests/older_versions/v030/test_deep_nested.py
@@ -80,7 +80,7 @@ def test_deep_nested_with_required_fields_without_value():
 
     assert str(e.value) == (
         "Cannot serialize model 'test_deep_nested.DeepNestedUni2' with key "
-        "'deep_nested_uni2/@temp_doc_id' due to error in field 'student.uni': "
+        f"'deep_nested_uni2/{u.id}' due to error in field 'student.uni': "
         '"uni" is required for model <class \'test_deep_nested.DeepNestedStudent2\'> '
         'but received no default and no value.'
     )
@@ -110,7 +110,7 @@ def test_deep_nested_with_required_fields():
         u.save()
     assert str(e.value) == (
         "Cannot serialize model 'test_deep_nested.DeepNestedUni3' with key "
-        "'deep_nested_uni3/@temp_doc_id' due to error in field 'student.uni': "
+        f"'deep_nested_uni3/{u.id}' due to error in field 'student.uni': "
         '"uni" is required for model <class \'test_deep_nested.DeepNestedStudent3\'> '
         'but received no default and no value.'
     )

--- a/src/tests/older_versions/v110/test_list_collections.py
+++ b/src/tests/older_versions/v110/test_list_collections.py
@@ -48,8 +48,7 @@ def test_list_subcollections():
     sub_doc.parent = doc.key
     sub_doc.save()
 
-    subcollections =  doc.list_subcollections()
-
+    subcollections = doc.list_subcollections()
 
     assert subcollections != ""
     assert subcollections == ["child"]

--- a/src/tests/v1.6.3/test_field_required_error_message.py
+++ b/src/tests/v1.6.3/test_field_required_error_message.py
@@ -19,7 +19,7 @@ def test_field_required_error_message():
     assert isinstance(e.value.original_error, RequiredField)
     assert str(e.value) == (
         "Cannot serialize model 'test_field_required_error_message.TestModel' with "
-        "key 'test_model/@temp_doc_id' due to error in field 'the_field': "
+        f"key 'test_model/{model.id}' due to error in field 'the_field': "
         '"the_field" is required for model <class '
         "'test_field_required_error_message.TestModel'> but received no default and "
         'no value.'

--- a/src/tests/v1.6.3/test_list_field_with_nested.py
+++ b/src/tests/v1.6.3/test_list_field_with_nested.py
@@ -3,13 +3,14 @@ import pytest
 from fireo.fields import errors, ListField, NestedModel, TextField
 from fireo.models import Model
 from fireo.models.errors import ModelSerializingWrappedError
+from fireo.utils.types import LoadOptions
 
 
 class LogAccessField(TextField):
     def db_value(self, val):
         return val + '<saved>'
 
-    def field_value(self, val, model, initial):
+    def field_value(self, val, load_options=LoadOptions()):
         return val + '<loaded>'
 
 

--- a/src/tests/v1.6/test_issue_160.py
+++ b/src/tests/v1.6/test_issue_160.py
@@ -72,13 +72,6 @@ def test_issue_160_custom_id():
         assert True == False
 
 
-def test_issue_160_should_throw_error_if_not_list_value():
-    class TestIssue160Model(Model):
-        name = TextField()
-
-    with pytest.raises(AttributeTypeError):
-        TestIssue160Model.collection.filter("id", "in", "not-list").fetch()
-
 def test_issue_160_should_able_to_get_with_key():
     class TestIssue160Model(Model):
         name = TextField()

--- a/src/tests/v1.8.0/test_collection_name_gen.py
+++ b/src/tests/v1.8.0/test_collection_name_gen.py
@@ -1,0 +1,13 @@
+from fireo.fields import TextField
+from fireo.models import Model
+
+
+class MyModel(Model):
+    class Meta:
+        collection_name_generator = lambda model_name: f'{model_name}test'
+
+    field = TextField()
+
+
+def test_collection_name_generator():
+    assert MyModel.collection_name == 'MyModeltest'

--- a/src/tests/v1.8.0/test_collection_name_gen.py
+++ b/src/tests/v1.8.0/test_collection_name_gen.py
@@ -9,5 +9,17 @@ class MyModel(Model):
     field = TextField()
 
 
+class OverrideColNameModel(Model):
+    class Meta:
+        collection_name_generator = lambda model_name: f'{model_name}test'
+        collection_name = 'MyOverride'
+
+    field = TextField()
+
+
 def test_collection_name_generator():
     assert MyModel.collection_name == 'MyModeltest'
+
+
+def test_collection_name_generator_override():
+    assert OverrideColNameModel.collection_name == 'MyOverride'

--- a/src/tests/v1.8.0/test_column_name_generator.py
+++ b/src/tests/v1.8.0/test_column_name_generator.py
@@ -1,0 +1,17 @@
+from fireo.fields import TextField
+from fireo.models import Model
+
+
+class MyModel(Model):
+    class Meta:
+        column_name_generator = str.upper
+
+    field_name = TextField()
+    second_field_name = TextField(column_name='TheSecond')
+
+
+def test_column_name_generator():
+    assert MyModel._meta.field_list['field_name'].db_column_name == 'FIELD_NAME'
+    assert MyModel._meta.field_list['second_field_name'].db_column_name == 'TheSecond'
+
+

--- a/src/tests/v1.8.0/test_create_subcollection.py
+++ b/src/tests/v1.8.0/test_create_subcollection.py
@@ -1,0 +1,17 @@
+from fireo.fields import TextField
+from fireo.models import Model
+
+
+class SubColModel(Model):
+    field = TextField()
+
+
+class MyModel(Model):
+    field = TextField()
+
+
+def test_create_subcollection():
+    main = MyModel(field='test').save()
+    sub = SubColModel.collection.parent(main.key).create(field='test')
+
+    assert sub.key == f'{main.key}/sub_col_model/{sub.id}'

--- a/src/tests/v1.8.0/test_default_factory.py
+++ b/src/tests/v1.8.0/test_default_factory.py
@@ -1,0 +1,23 @@
+from fireo.fields import TextField
+from fireo.models import Model
+
+
+def test_call_default_factory_if_no_value():
+    class MyModel(Model):
+        field = TextField(default_factory=lambda: 'default factory')
+
+    model = MyModel()
+    model.save()
+    assert model.field == 'default factory'
+
+
+def test_default_factory_is_not_called_if_default_exists():
+    class MyModel(Model):
+        field = TextField(
+            default_factory=lambda: 'default value',
+            default='default value',
+        )
+
+    model = MyModel()
+    model.save()
+    assert model.field == 'default value'

--- a/src/tests/v1.8.0/test_document_path.py
+++ b/src/tests/v1.8.0/test_document_path.py
@@ -1,0 +1,28 @@
+from fireo.fields import TextField
+from fireo.models import Model
+
+
+def test_model_document_path():
+    class Doc(Model):
+        doc_id = TextField()
+
+    class SubDoc(Model):
+        doc_id = TextField()
+
+    doc = Doc(doc_id="parent")
+    doc.save()
+
+    sub_doc = SubDoc(doc_id="child")
+    sub_doc.parent = doc.key
+    sub_doc.save()
+
+    assert doc.document_path == '/'.join([
+        doc.collection_name,
+        doc.id,
+    ])
+    assert sub_doc.document_path == '/'.join([
+        doc.collection_name,
+        doc.id,
+        sub_doc.collection_name,
+        sub_doc.id
+    ])

--- a/src/tests/v1.8.0/test_filter_by_id_field.py
+++ b/src/tests/v1.8.0/test_filter_by_id_field.py
@@ -1,0 +1,18 @@
+from google.cloud.firestore_v1.field_path import FieldPath
+
+from fireo import db
+from fireo.fields import IDField, TextField
+from fireo.models import Model
+
+
+class MyModel(Model):
+    custom_id = IDField(include_in_document=True)
+    field = TextField(column_name='alias')
+
+
+def test_filter_by_id_field_in_doc():
+    db.conn.collection(MyModel.collection_name).add({'custom_id': '111', 'alias': 'value'}, '222')
+
+    assert MyModel.collection.filter('custom_id', '==', '111').get().field == 'value'
+    assert MyModel.collection.filter('_id', '==', '222').get().field == 'value'
+    assert MyModel.collection.filter(FieldPath.document_id(), '==', '222').get().field == 'value'

--- a/src/tests/v1.8.0/test_id_in_document.py
+++ b/src/tests/v1.8.0/test_id_in_document.py
@@ -1,0 +1,21 @@
+from fireo import db
+from fireo.fields import IDField, TextField
+from fireo.models import Model
+
+
+class MyModel(Model):
+    id = IDField(include_in_document=True)
+    field1 = TextField()
+
+
+def test_abstract_instance_has_no_id():
+    model = MyModel(field1='test', id='test_id')
+
+    model.save()
+
+    doc = db.conn.document(model.key).get()
+    doc_dict = doc.to_dict()
+    assert model.id == 'test_id'
+    assert doc.id == model.id
+    assert doc_dict['id'] == model.id
+    assert doc_dict['field1'] == model.field1

--- a/src/tests/v1.8.0/test_id_in_document.py
+++ b/src/tests/v1.8.0/test_id_in_document.py
@@ -3,12 +3,11 @@ from fireo.fields import IDField, TextField
 from fireo.models import Model
 
 
-class MyModel(Model):
-    id = IDField(include_in_document=True)
-    field1 = TextField()
+def test_id_with_include_in_document_added_as_field():
+    class MyModel(Model):
+        id = IDField(include_in_document=True)
+        field1 = TextField()
 
-
-def test_abstract_instance_has_no_id():
     model = MyModel(field1='test', id='test_id')
 
     model.save()
@@ -19,3 +18,45 @@ def test_abstract_instance_has_no_id():
     assert doc.id == model.id
     assert doc_dict['id'] == model.id
     assert doc_dict['field1'] == model.field1
+
+
+def test_populate_id_field_in_document_on_create():
+    class MyModel(Model):
+        id = IDField(include_in_document=True)
+        field1 = TextField()
+
+    model = MyModel(field1='test')
+    model.save()
+
+    doc = db.conn.document(model.key).get()
+    doc_dict = doc.to_dict()
+    assert model.id == doc.id
+    assert doc_dict.get('id') == doc.id
+
+
+def test_populate_custom_id_field_in_document_on_create():
+    class MyModel(Model):
+        custom_id = IDField(include_in_document=True)
+        field1 = TextField()
+
+    model = MyModel(field1='test')
+    model.save()
+
+    doc = db.conn.document(model.key).get()
+    doc_dict = doc.to_dict()
+    assert model.custom_id == doc.id
+    assert doc_dict.get('custom_id') == doc.id
+
+
+def test_populate_required_custom_id_field_in_document_on_create():
+    class MyModel(Model):
+        custom_id = IDField(include_in_document=True, required=True)
+        field1 = TextField()
+
+    model = MyModel(field1='test')
+    model.save()
+
+    doc = db.conn.document(model.key).get()
+    doc_dict = doc.to_dict()
+    assert model.custom_id == doc.id
+    assert doc_dict.get('custom_id') == doc.id

--- a/src/tests/v1.8.0/test_ignore_none_field.py
+++ b/src/tests/v1.8.0/test_ignore_none_field.py
@@ -1,5 +1,5 @@
 from fireo import db
-from fireo.fields import NestedModelField, TextField
+from fireo.fields import ListField, NestedModelField, TextField
 from fireo.models import Model
 
 
@@ -18,6 +18,7 @@ class IgnoreNoneModel(Model):
     field1 = TextField()
     field2 = TextField(default='default')
     nested = NestedModelField(NestedIgnoreNoneModel)
+    list_fields = ListField()
 
 
 def test_ignore_default_none_on_create():

--- a/src/tests/v1.8.0/test_inherit_meta.py
+++ b/src/tests/v1.8.0/test_inherit_meta.py
@@ -1,0 +1,30 @@
+from fireo.fields import TextField
+from fireo.managers.managers import Manager
+from fireo.models import Model
+
+
+def test_inherit_meta_fields():
+    class CustomManager(Manager):
+        pass
+
+    class AbstractModel(Model):
+        name = TextField()
+
+        class Meta:
+            collection_name = 'first'
+            abstract = True
+            to_lowercase = True
+            missing_field = 'raise_error'
+            ignore_none_field = False
+            default_manager_cls = CustomManager
+
+    class ActualModel(AbstractModel):
+        pass
+
+    assert ActualModel._meta.collection_name != 'first', 'Collection name should not be inherited'
+    assert ActualModel._meta.abstract is False, 'Abstract should not be inherited'
+    assert ActualModel._meta.to_lowercase is True
+    assert ActualModel._meta.missing_field == 'raise_error'
+    assert ActualModel._meta.ignore_none_field is False
+    assert ActualModel._meta.default_manager_cls == CustomManager
+    assert ActualModel.collection.__class__ == CustomManager

--- a/src/tests/v1.8.0/test_list_field_with_complex_nested.py
+++ b/src/tests/v1.8.0/test_list_field_with_complex_nested.py
@@ -63,12 +63,13 @@ def test_error_message_has_list_index():
         list_field = ListField(nested_field=NestedModelField(NestedModel))
 
     with pytest.raises(ModelSerializingWrappedError) as e:
-        TestModel.from_dict(dict(list_field=[dict(field='str')])).save()
+        m = TestModel.from_dict(dict(list_field=[dict(field='str')]))
+        m.save()
 
     assert str(e.value) == (
         'Cannot serialize model '
         "'test_list_field_with_complex_nested.test_error_message_has_list_index.<locals>.TestModel' "
-        "with key 'test_model/@temp_doc_id' due to error in field "
+        f"with key 'test_model/{m.id}' due to error in field "
         '\'list_field[0].field2\': "field2" is required for model <class '
         "'test_list_field_with_complex_nested.test_error_message_has_list_index.<locals>.NestedModel'> "
         'but received no default and no value.'

--- a/src/tests/v1.8.0/test_load_from_dict.py
+++ b/src/tests/v1.8.0/test_load_from_dict.py
@@ -1,0 +1,21 @@
+from fireo.fields import TextField
+from fireo.models import Model
+
+
+class MyModel(Model):
+    class Meta:
+        missing_field = 'raise_error'
+
+    value = TextField(column_name='db_value')
+
+
+def test_load_from_dict_by_name():
+    model = MyModel.from_dict({'value': 'value'}, by_column_name=False)
+
+    assert model.value == 'value'
+
+
+def test_load_from_dict_by_column_name():
+    model = MyModel.from_dict({'db_value': 'value'}, by_column_name=True)
+
+    assert model.value == 'value'

--- a/src/tests/v1.8.0/test_merge_with_dict.py
+++ b/src/tests/v1.8.0/test_merge_with_dict.py
@@ -1,0 +1,60 @@
+from fireo.fields import ListField, NestedModelField, TextField
+from fireo.models import Model
+
+
+class MyNestedModel(Model):
+    field1 = TextField()
+    field2 = TextField()
+    field3 = TextField()
+
+
+class MyModel(Model):
+    field1 = TextField()
+    field2 = TextField()
+    field3 = TextField()
+    nested = NestedModelField(MyNestedModel)
+    nested_list = ListField(NestedModelField(MyNestedModel))
+
+
+def test_merge_with_dict_works_with_nested():
+    model = MyModel()
+    model.field1 = "value1"
+    model.field2 = "value2"
+    model.field3 = "value3"
+    model.nested.field1 = "nested_value1"
+    model.nested.field2 = "nested_value2"
+    model.nested.field3 = "nested_value3"
+
+    model.merge_with_dict({
+        "field1": None,
+        "field2": "changed_value2",
+        "nested": {
+            "field1": None,
+            "field2": "changed_nested_value2",
+        }
+    })
+
+    assert model.field1 is None
+    assert model.field2 == "changed_value2"
+    assert model.field3 == "value3"
+    assert model.nested.field1 is None
+    assert model.nested.field2 == "changed_nested_value2"
+    assert model.nested.field3 == "nested_value3"
+
+
+def test_merge_with_dict_replaces_list_values():
+    model = MyModel()
+    model.nested_list = [
+        MyNestedModel(field1="value1", field2="value2", field3="value3"),
+        MyNestedModel(field1="value4", field2="value5", field3="value6"),
+    ]
+    model.merge_with_dict({
+        "nested_list": [
+            {"field1": "changed_value1", "field2": "changed_value2"},
+        ]
+    })
+
+    assert len(model.nested_list) == 1
+    assert model.nested_list[0].field1 == "changed_value1"
+    assert model.nested_list[0].field2 == "changed_value2"
+    assert model.nested_list[0].field3 is None

--- a/src/tests/v1.8.0/test_mutable_default.py
+++ b/src/tests/v1.8.0/test_mutable_default.py
@@ -1,0 +1,15 @@
+from fireo.fields import ListField
+from fireo.models import Model
+
+
+class MyModel(Model):
+    field = ListField(default=[])
+
+
+def test_copy_default_mutable_values():
+    model1 = MyModel()
+    model1.save()
+    model2 = MyModel()
+    model2.save()
+
+    assert model1.field is not model2.field

--- a/src/tests/v1.8.0/test_ordering_by_nested.py
+++ b/src/tests/v1.8.0/test_ordering_by_nested.py
@@ -1,0 +1,19 @@
+from fireo.fields import MapField, NestedModelField
+from fireo.models import Model
+
+
+class Nested(Model):
+    b = MapField(column_name='bb')
+
+
+class TestModel(Model):
+    a = NestedModelField(Nested, column_name='aa')
+
+
+def test_order_by_nested():
+    TestModel.from_dict({'a': {'b': {'c': {'d': 1}}}}).save()
+    TestModel.from_dict({'a': {'b': {'c': {'d': 2}}}}).save()
+    TestModel.from_dict({'a': {'b': {'c': {'d': 3}}}}).save()
+
+    assert [m.a.b['c']['d'] for m in TestModel.collection.order('a.b.c.d').fetch()] == [1, 2, 3]
+    assert [m.a.b['c']['d'] for m in TestModel.collection.order('-a.b.c.d').fetch()] == [3, 2, 1]

--- a/src/tests/v1.8.0/test_refresh_model.py
+++ b/src/tests/v1.8.0/test_refresh_model.py
@@ -1,0 +1,46 @@
+from google.cloud import firestore
+
+from fireo import db
+from fireo.fields import NestedModelField, TextField
+from fireo.models import Model
+
+
+class MyNestedModel(Model):
+    field1 = TextField()
+    field2 = TextField()
+    field3 = TextField()
+
+
+class MyModel(Model):
+    field1 = TextField()
+    field2 = TextField()
+    field3 = TextField()
+    nested = NestedModelField(MyNestedModel)
+
+
+def test_changed_in_db():
+    model = MyModel()
+    model.field1 = "value1"
+    model.field2 = "value2"
+    model.field3 = "value3"
+    model.nested.field1 = "nested_value1"
+    model.nested.field2 = "nested_value2"
+    model.nested.field3 = "nested_value3"
+    model.save()
+
+    db.conn.collection(MyModel.collection_name).document(model.id).update({
+        "field1": firestore.DELETE_FIELD,
+        "field2": "changed_value2",
+        "nested.field1": firestore.DELETE_FIELD,
+        "nested.field2": "changed_nested_value2",
+    })
+
+    model.refresh()
+
+    assert model.field1 is None
+    assert model.field2 == "changed_value2"
+    assert model.field3 == "value3"
+    assert model.nested.field1 is None
+    assert model.nested.field2 == "changed_nested_value2"
+    assert model.nested.field3 == "nested_value3"
+

--- a/src/tests/v1.8.0/test_set_id_on_batch_create.py
+++ b/src/tests/v1.8.0/test_set_id_on_batch_create.py
@@ -1,0 +1,17 @@
+import fireo
+from fireo.fields import TextField
+from fireo.models import Model
+
+
+class MyModel(Model):
+    field = TextField()
+
+
+def test_set_id_on_batch_create():
+    model = MyModel(field='test')
+
+    with fireo.batch() as batch:
+        model.save(batch=batch)
+
+    assert model.id is not None
+    assert MyModel.collection.get(model.key).field == 'test'

--- a/src/tests/v1.8.0/test_update_doc_with_list.py
+++ b/src/tests/v1.8.0/test_update_doc_with_list.py
@@ -1,0 +1,19 @@
+from fireo.fields import ListField, TextField
+from fireo.models import Model
+
+
+class MyModel(Model):
+    field = TextField()
+    list_field = ListField()
+
+
+def test_update_doc_with_list():
+    m = MyModel(field='value')
+    m.list_field = ['list_value']
+    m.save()
+
+    m.list_field.append('another_value')
+    m.update()
+
+    m = MyModel.collection.get(m.key)
+    assert m.list_field == ['list_value', 'another_value']


### PR DESCRIPTION
[Merge after ADR-007:bugfix/fix-model-list-subcollections]

- Allow model._meta field inheritance
- Allow change default manager class
- Use `id` as default doc_id field (it is before, but implicit and not always)
- Add `by_colum_name` to Model.from_dict
- Fix ordering by nested fields
- Add Meta.column_name_generator (can be used to generate camelCase column names)
- Add Model.refresh
- Add model.merge_with_dict
- Add IDField.include_in_document
- Set Meta.abstract = True in base model
- [Save doc.id on batch create](https://github.com/octabytes/FireO/pull/184/commits/086a9e82184351aec65a30d2b6ab261f114af961)
- [Add Meta.collection_name_generator](https://github.com/octabytes/FireO/pull/184/commits/ed8e1a456a5079032a4dcc964137c84611ecd185)
- [Use collection.parent() in .create()](https://github.com/octabytes/FireO/pull/184/commits/1c8ad3a14061a9646a1f473bbbe04fbcc3c10c87)
- Generate Model.id by IDField
- Allow required=True in IDField
- Add default_factory
- Add copy for default values