### PR TITLE
Auto-create nested models for required fields only

### DIFF
--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -161,7 +161,8 @@ class Model(metaclass=ModelMeta):
         for f in self._meta.field_list.values():
             if isinstance(f, fields.NestedModelField):
                 if f.name not in kwargs:
-                    setattr(self, f.name, f.nested_model())
+                    if f.raw_attributes.get('required', False):
+                        setattr(self, f.name, f.nested_model())
                 elif isinstance(kwargs[f.name], dict):
                     warnings.warn(
                         'Use Model.from_dict to deserialize from dict',

--- a/src/tests/older_versions/v030/test_deep_nested.py
+++ b/src/tests/older_versions/v030/test_deep_nested.py
@@ -12,12 +12,12 @@ class DeepNestedUser(Model):
 
 class DeepNestedStudent(Model):
     uni = TextField(required=True)
-    user = NestedModel(DeepNestedUser)
+    user = NestedModel(DeepNestedUser, required=True)
 
 
 class DeepNestedUni(Model):
     dept = TextField()
-    student = NestedModel(DeepNestedStudent)
+    student = NestedModel(DeepNestedStudent, required=True)
 
 
 def test_simple_deep_nested():
@@ -62,12 +62,12 @@ class DeepNestedUser2(Model):
 
 class DeepNestedStudent2(Model):
     uni = TextField(required=True)
-    user = NestedModel(DeepNestedUser2)
+    user = NestedModel(DeepNestedUser2, required=True)
 
 
 class DeepNestedUni2(Model):
     dept = TextField()
-    student = NestedModel(DeepNestedStudent2)
+    student = NestedModel(DeepNestedStudent2, required=True)
 
 
 def test_deep_nested_with_required_fields_without_value():
@@ -93,7 +93,7 @@ class DeepNestedUser3(Model):
 
 class DeepNestedStudent3(Model):
     uni = TextField(required=True)
-    user = NestedModel(DeepNestedUser3)
+    user = NestedModel(DeepNestedUser3, required=True)
 
 
 class DeepNestedUni3(Model):

--- a/src/tests/older_versions/v030/test_nested_filter.py
+++ b/src/tests/older_versions/v030/test_nested_filter.py
@@ -58,12 +58,12 @@ class NFLevel1(Model):
 
 class NFLevel2(Model):
     age = NumberField()
-    lev1 = NestedModel(NFLevel1)
+    lev1 = NestedModel(NFLevel1, required=True)
 
 
 class NFLevel3(Model):
     dept = TextField()
-    lev2 = NestedModel(NFLevel2)
+    lev2 = NestedModel(NFLevel2, required=True)
 
 
 def test_deep_nested_filter_without_column_name():
@@ -86,12 +86,12 @@ class NFLevel4(Model):
 
 class NFLevel5(Model):
     age = NumberField()
-    lev4 = NestedModel(NFLevel4, column_name='lev4')
+    lev4 = NestedModel(NFLevel4, column_name='lev4', required=True)
 
 
 class NFLevel6(Model):
     dept = TextField()
-    lev5 = NestedModel(NFLevel5, column_name='lev5')
+    lev5 = NestedModel(NFLevel5, column_name='lev5', required=True)
 
 
 def test_deep_nested_filter_with_column_name():

--- a/src/tests/older_versions/v113/test_convert_model_into_dict.py
+++ b/src/tests/older_versions/v113/test_convert_model_into_dict.py
@@ -35,7 +35,7 @@ def test_nested_model_to_dict():
 
     class ConvertModelIntoDict(Model):
         name = TextField()
-        nested_parent = NestedModel(NestedParent)
+        nested_parent = NestedModel(NestedParent, required=True)
 
     c = ConvertModelIntoDict()
     c.name = 'Azeem'
@@ -57,7 +57,7 @@ def test_nested_model_default_args_to_dict():
 
     class ConvertModelIntoDict(Model):
         name = TextField()
-        nested_parent = NestedModel(NestedParent)
+        nested_parent = NestedModel(NestedParent, required=True)
 
     c = ConvertModelIntoDict()
     c.name = 'Azeem'

--- a/src/tests/v1.8.0/test_ignore_none_field.py
+++ b/src/tests/v1.8.0/test_ignore_none_field.py
@@ -17,7 +17,7 @@ class IgnoreNoneModel(Model):
 
     field1 = TextField()
     field2 = TextField(default='default')
-    nested = NestedModelField(NestedIgnoreNoneModel)
+    nested = NestedModelField(NestedIgnoreNoneModel, required=True)
     list_fields = ListField()
 
 
@@ -59,7 +59,7 @@ class NotIgnoreNoneModel(Model):
 
     field1 = TextField()
     field2 = TextField(default='default')
-    nested = NestedModelField(NestedIgnoreNoneModel)
+    nested = NestedModelField(NestedIgnoreNoneModel, required=True)
 
 
 def test_not_ignore_default_none_on_create():

--- a/src/tests/v1.8.0/test_merge_with_dict.py
+++ b/src/tests/v1.8.0/test_merge_with_dict.py
@@ -12,7 +12,7 @@ class MyModel(Model):
     field1 = TextField()
     field2 = TextField()
     field3 = TextField()
-    nested = NestedModelField(MyNestedModel)
+    nested = NestedModelField(MyNestedModel, required=True)
     nested_list = ListField(NestedModelField(MyNestedModel))
 
 

--- a/src/tests/v1.8.0/test_refresh_model.py
+++ b/src/tests/v1.8.0/test_refresh_model.py
@@ -15,7 +15,7 @@ class MyModel(Model):
     field1 = TextField()
     field2 = TextField()
     field3 = TextField()
-    nested = NestedModelField(MyNestedModel)
+    nested = NestedModelField(MyNestedModel, required=True)
 
 
 def test_changed_in_db():

--- a/src/tests/v1.8.0/test_update_with_nested.py
+++ b/src/tests/v1.8.0/test_update_with_nested.py
@@ -10,13 +10,13 @@ class Deep0Model(Model):
 class Deep1Model(Model):
     my_field = TextField()
     my_field2 = TextField()
-    my_nested_model = NestedModel(Deep0Model)
+    my_nested_model = NestedModel(Deep0Model, required=True)
 
 
 class Deep2Model(Model):
     my_field = TextField()
     my_field2 = TextField()
-    my_nested_model = NestedModel(Deep1Model)
+    my_nested_model = NestedModel(Deep1Model, required=True)
 
 
 def test_update_first_level_in_model_with_nested():

--- a/src/tests/v2.1.0/test_optional_nested.py
+++ b/src/tests/v2.1.0/test_optional_nested.py
@@ -1,0 +1,19 @@
+from fireo.fields import NestedModelField, TextField
+from fireo.models import Model
+
+
+class MyNested(Model):
+    my_required_field = TextField(required=True)
+
+
+class MyModel(Model):
+    some_field = TextField()
+    my_nested = NestedModelField(MyNested)
+
+
+def test_can_create_model_without_optional_nested_model():
+    my_model = MyModel()
+    my_model.some_field = "some value"
+
+    assert my_model.my_nested is None
+    my_model.save()


### PR DESCRIPTION
Problem: models with optional nested fields cannot be saved:
```python
from fireo.fields import NestedModelField, TextField
from fireo.models import Model


class MyNested(Model):
    my_required_field = TextField(required=True)


class MyModel(Model):
    some_field = TextField()
    my_nested = NestedModelField(MyNested, default=None)  # "None" is the default value for default anyway


my_model = MyModel()
my_model.some_field = "some value"
my_model.save()  # error! my_required_field is required
```