### PR TITLE
Feature/Immutable FilterQuery and Manager (copy instead of changing)

### DIFF
--- a/src/fireo/fields/number_field.py
+++ b/src/fireo/fields/number_field.py
@@ -52,6 +52,17 @@ class NumberField(Field):
 
     # override method
     def db_value(self, val):
+        if isinstance(val, str):
+            # Allow using string values for numbers. In filters as well.
+            org_val = val
+            try:
+                if not self.raw_attributes.get('int_only'):
+                    val = float(org_val)
+                if not self.raw_attributes.get('float_only'):
+                    val = int(org_val)
+            except ValueError:
+                pass
+
         if type(val) in [int, float, Increment] or val is None:
             return val
         raise errors.InvalidFieldType(f'Invalid field type. Field "{self.name}" expected {int} or {float}, '

--- a/src/fireo/fields/number_field.py
+++ b/src/fireo/fields/number_field.py
@@ -1,4 +1,4 @@
-from google.cloud.firestore_v1 import Increment
+from google.cloud.firestore_v1.transforms import _NumericValue
 
 from fireo.fields import errors
 from fireo.fields.base_field import Field
@@ -38,14 +38,14 @@ class NumberField(Field):
 
     def attr_int_only(self, attr_val, field_val):
         """Method for attribute int_only"""
-        if attr_val and type(field_val) is not int:
+        if attr_val is not None and not isinstance(get_real_value(field_val), int):
             raise errors.InvalidFieldType(f'Invalid field type. Field "{self.name}" expected {int} type, '
                                           f'got {type(field_val)}')
         return field_val
 
     def attr_float_only(self, attr_val, field_val):
         """Method for attribute float_only"""
-        if attr_val and type(field_val) is not float:
+        if attr_val is not None and not isinstance(get_real_value(field_val), float):
             raise errors.InvalidFieldType(f'Invalid field type. Field "{self.name}" expected {float} type, '
                                           f'got {type(field_val)}')
         return field_val
@@ -63,7 +63,13 @@ class NumberField(Field):
             except ValueError:
                 pass
 
-        if type(val) in [int, float, Increment] or val is None:
+        if isinstance(get_real_value(val), (int, float)) or val is None:
             return val
         raise errors.InvalidFieldType(f'Invalid field type. Field "{self.name}" expected {int} or {float}, '
                                       f'got {type(val)}')
+
+
+def get_real_value(val):
+    if isinstance(val, _NumericValue):
+        return val.value
+    return val

--- a/src/fireo/fields/reference_field.py
+++ b/src/fireo/fields/reference_field.py
@@ -76,12 +76,18 @@ class ReferenceField(Field):
         # if no model is provided then return None
         if model is None:
             return None
+
+        # if model is string then return document reference
+        # Used for filtering by key instead of model
+        if isinstance(model, str):
+            return db.conn.document(model)
+
         # check reference model and passing model is same
         if not issubclass(model.__class__, self.model_ref):
             raise errors.ReferenceTypeError(f'Invalid reference type. Field "{self.name}" required value type '
                                             f'"{self.model_ref.__name__}", but got "{model.__class__.__name__}"')
         # Get document reference from firestore
-        return firestore.DocumentReference(*utils.ref_path(model.key), client=db.conn)
+        return db.conn.document(model.key)
 
     def attr_auto_load(self, attr_val, field_val):
         """Attribute method for auto load

--- a/src/fireo/managers/managers.py
+++ b/src/fireo/managers/managers.py
@@ -134,7 +134,7 @@ class Manager:
         }
 
     def copy(self, **kwargs) -> "Manager":
-        return Manager(**{**self._deconstruct(), **kwargs})
+        return type(self)(**{**self._deconstruct(), **kwargs})
 
     def contribute_to_model(self, model_cls, name="collection"):
         """Attach manager to model class

--- a/src/fireo/managers/managers.py
+++ b/src/fireo/managers/managers.py
@@ -2,6 +2,7 @@ import base64
 import json
 
 from fireo.queries.query_set import QuerySet
+from fireo.utils.cursor import Cursor
 
 
 class ManagerError(Exception):
@@ -199,6 +200,7 @@ class Manager:
 
     def parent(self, key):
         """Parent collection"""
+        # todo: fix it
         self._parent_key = key
         return self
 
@@ -257,26 +259,7 @@ class Manager:
 
         Cursor define where to start the query
         """
-        parent = self._parent_key
-        cursor_dict = json.loads(base64.b64decode(cursor))
-        if 'parent' in cursor_dict:
-            parent = cursor_dict['parent']
-        query = self.queryset.filter(parent)
-        if 'filters' in cursor_dict:
-            for filter in cursor_dict['filters']:
-                query.filter(*filter)
-        if 'order' in cursor_dict:
-            query.order(cursor_dict['order'])
-        if 'limit' in cursor_dict:
-            query.limit(cursor_dict['limit'])
-
-        # check if last doc key is available or not
-        if 'last_doc_key' in cursor_dict:
-            query.start_after(key=cursor_dict['last_doc_key'])
-        else:
-            query.offset(cursor_dict['offset'])
-
-        return query
+        return Cursor.from_string(cursor).apply(self._parent_key, self.queryset)
 
     def start_after(self, key=None, **kwargs):
         """Start document after this key or after that matching fields"""

--- a/src/fireo/managers/managers.py
+++ b/src/fireo/managers/managers.py
@@ -130,6 +130,7 @@ class Manager:
         return {
             "model_cls": self.model_cls,
             "name": self.name,
+            "parent_key": self._parent_key,
         }
 
     def copy(self, **kwargs) -> "Manager":

--- a/src/fireo/managers/managers.py
+++ b/src/fireo/managers/managers.py
@@ -1,5 +1,6 @@
 import base64
 import json
+from typing import Any, Dict
 
 from fireo.queries.query_set import QuerySet
 from fireo.utils.cursor import Cursor
@@ -120,10 +121,19 @@ class Manager:
         End document at this key or at that matching fields
     """
 
-    def __init__(self):
-        self.model_cls = None
-        self.name = None
-        self._parent_key = None
+    def __init__(self, *, model_cls=None, name=None, parent_key=None):
+        self.model_cls = model_cls
+        self.name = name
+        self._parent_key = parent_key
+
+    def _deconstruct(self) -> Dict[str, Any]:
+        return {
+            "model_cls": self.model_cls,
+            "name": self.name,
+        }
+
+    def copy(self, **kwargs) -> "Manager":
+        return Manager(**{**self._deconstruct(), **kwargs})
 
     def contribute_to_model(self, model_cls, name="collection"):
         """Attach manager to model class
@@ -200,9 +210,7 @@ class Manager:
 
     def parent(self, key):
         """Parent collection"""
-        # todo: fix it
-        self._parent_key = key
-        return self
+        return self.copy(parent_key=key)
 
     def filter(self, *args, **kwargs):
         """Get filter document from firestore"""

--- a/src/fireo/models/model.py
+++ b/src/fireo/models/model.py
@@ -57,9 +57,6 @@ class Model(metaclass=ModelMeta):
         Model key which contain the model collection name and model id and parent if provided, Id can be user defined
         or generated from firestore
 
-    _update_doc: str
-        Update doc hold the key which is used to update the document
-
     parent: str
         Parent key if user specify
 
@@ -124,9 +121,6 @@ class Model(metaclass=ModelMeta):
     # Track which fields are changed or not
     # it is useful when updating document
     _field_changed = None
-
-    # Update doc hold the key which is used to update the document
-    _update_doc = None
 
     _create_time = None
     _update_time = None
@@ -505,16 +499,16 @@ class Model(metaclass=ModelMeta):
         """
 
         # Check doc key is given or not
-        if key:
-            self._update_doc = key
+        if not key:
+            key = self.key
 
         # make sure update doc in not None
-        if self._update_doc is not None and '@temp_doc_id' not in self._update_doc:
+        if key is not None and '@temp_doc_id' not in key:
             # set parent doc from this updated document key
-            self.parent = utils.get_parent_doc(self._update_doc)
+            self.parent = utils.get_parent_doc(key)
             # Get id from key and set it for model
-            self._id = utils.get_id(self._update_doc)
-        elif self._update_doc is None and '@temp_doc_id' in self.key:
+            self._id = utils.get_id(key)
+        elif key is None and '@temp_doc_id' in self.key:
             raise InvalidKey(
                 f'Invalid key to update model "{self.__class__.__name__}" ')
 

--- a/src/fireo/queries/base_query.py
+++ b/src/fireo/queries/base_query.py
@@ -1,8 +1,9 @@
 import inspect
+from typing import Any, Dict
 
 from fireo.database import db
-from fireo.utils import utils
 from fireo.queries import errors
+from fireo.utils import utils
 
 
 class BaseQuery:
@@ -23,13 +24,22 @@ class BaseQuery:
         Validate the key
     """
 
-    def __init__(self, model_cls):
+    def __init__(self, model_cls, *, group_collection=False):
         self.model_cls = model_cls
         # if collection path and model key both are not available then
         # collection_name will be the base collection path
         self.collection_path = model_cls.collection_name
         # Firestore allow to get documents from group collection
-        self.group_collection = False
+        self.group_collection = group_collection
+
+    def _deconstruct(self) -> Dict[str, Any]:
+        return {
+            'model_cls': self.model_cls,
+            'group_collection': self.group_collection,
+        }
+
+    def copy(self, **kwargs):
+        return self.__class__(**{**self._deconstruct(), **kwargs})
 
     def set_collection_path(self, path=None, key=None):
         """Set collection path"""

--- a/src/fireo/queries/base_query.py
+++ b/src/fireo/queries/base_query.py
@@ -39,7 +39,7 @@ class BaseQuery:
         }
 
     def copy(self, **kwargs):
-        return self.__class__(**{**self._deconstruct(), **kwargs})
+        return type(self)(**{**self._deconstruct(), **kwargs})
 
     def set_collection_path(self, path=None, key=None):
         """Set collection path"""

--- a/src/fireo/queries/create_query.py
+++ b/src/fireo/queries/create_query.py
@@ -41,16 +41,6 @@ class CreateQuery(BaseQuery):
         for k, v in kwargs.items():
             setattr(self.model, k, v)
 
-        # Attach key to this model for updating this model
-        # Purpose of attaching this key is user can update
-        # this model after getting it
-        #
-        # For example:
-        #   u = User.collection.create(name="Azeem", age=25)
-        #   u.name = "Updated Name"
-        #   u.update()
-        self.model._update_doc = self.model.key
-
     def _doc_ref(self):
         """create document ref from firestore"""
         return self.get_ref().document(self.model._id)

--- a/src/fireo/queries/filter_query.py
+++ b/src/fireo/queries/filter_query.py
@@ -11,6 +11,7 @@ from fireo.queries.base_query import BaseQuery
 from fireo.queries.delete_query import DeleteQuery
 from fireo.queries.query_iterator import QueryIterator
 from fireo.utils import utils
+from fireo.utils.cursor import Cursor
 from fireo.utils.types import DumpOptions
 from fireo.utils.utils import (
     get_dot_names_as_dot_columns,
@@ -382,10 +383,16 @@ class FilterQuery(BaseQuery):
         limit : optional
             Apply limit to firestore documents, how much documents you want to retrieve
         """
-        query = self
+        fq = self
         if limit:
-            query = self.copy(limit=limit)
-        return QueryIterator(query)  # todo
+            fq = self.copy(limit=limit)
+        return QueryIterator(
+            model_cls=fq.model_cls,
+            query=fq.query,
+            query_transaction=fq._query_transaction,
+            limit=fq._limit,
+            cursor=Cursor.extract(fq),
+        )
 
     def group_fetch(self, limit=None):
         return self.copy(group_collection=True).fetch(limit)

--- a/src/fireo/queries/filter_query.py
+++ b/src/fireo/queries/filter_query.py
@@ -421,7 +421,6 @@ class FilterQuery(BaseQuery):
         doc = next(self.query().stream(self.query_transaction), None)
         if doc:
             m = query_wrapper.ModelWrapper.from_query_result(self.model, doc)
-            m._update_doc = self._update_doc_key(m)
             return m
         return None
 

--- a/src/fireo/queries/get_query.py
+++ b/src/fireo/queries/get_query.py
@@ -46,7 +46,6 @@ class GetQuery(BaseQuery):
         #   u = User.collection.get(user_key)
         #   u.name = "Updated Name"
         #   u.update()
-        self.model._update_doc = key
         self.id = utils.get_id(key)
 
     def _raw_exec(self, transaction=None):

--- a/src/fireo/queries/query_iterator.py
+++ b/src/fireo/queries/query_iterator.py
@@ -1,11 +1,13 @@
 import itertools
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
+
+from google.cloud.firestore_v1 import CollectionReference, Transaction
 
 from fireo.queries import query_wrapper
 from fireo.utils.cursor import Cursor
 
 if TYPE_CHECKING:
-    from fireo.queries.filter_query import FilterQuery
+    pass
 
 
 class QueryIterator:
@@ -20,14 +22,22 @@ class QueryIterator:
         Fetch next results
     """
 
-    def __init__(self, query: 'FilterQuery'):  # todo
+    def __init__(
+        self,
+        model_cls,
+        query: CollectionReference,
+        query_transaction: Optional[Transaction],
+        limit: Optional[int],
+        cursor: Cursor,
+    ):
         self.query = query
-        self.model_cls = query.model_cls
-        self.docs = query.query.stream(query._query_transaction)
+        self.model_cls = model_cls
+        self.docs = query.stream(query_transaction)
+        self.limit = limit
 
         # Get offset for next fetch
-        self.offset = query._limit
-        self._cursor = Cursor.extract(query)
+        self.offset = limit
+        self._cursor = cursor
         self._cursor['offset'] = self.offset
 
         # Hold the last doc for next fetch
@@ -63,16 +73,16 @@ class QueryIterator:
             # check if fetch end then use last doc otherwise use the offset
             if self.fetch_end:
                 self.fetch_end = False
-                q = self.query.query.start_after(self.last_doc)
+                q = self.query.start_after(self.last_doc)
             else:
-                q = self.query.query.offset(self.offset)
+                q = self.query.offset(self.offset)
 
             # Apply new Limit if there is any
             if limit:
                 q = q.limit(limit)
                 self.offset += limit
             else:
-                self.offset += self.query._limit
+                self.offset += self.limit
 
             # Update offset in cursor
             self._cursor['offset'] = self.offset

--- a/src/fireo/queries/query_iterator.py
+++ b/src/fireo/queries/query_iterator.py
@@ -1,6 +1,4 @@
-import base64
 import itertools
-import json
 from typing import TYPE_CHECKING
 
 from fireo.queries import query_wrapper
@@ -22,13 +20,13 @@ class QueryIterator:
         Fetch next results
     """
 
-    def __init__(self, query: 'FilterQuery'):
+    def __init__(self, query: 'FilterQuery'):  # todo
         self.query = query
         self.model_cls = query.model_cls
-        self.docs = query.query().stream(query.query_transaction)
+        self.docs = query.query.stream(query._query_transaction)
 
         # Get offset for next fetch
-        self.offset = query.n_limit
+        self.offset = query._limit
         self._cursor = Cursor.extract(query)
         self._cursor['offset'] = self.offset
 
@@ -65,16 +63,16 @@ class QueryIterator:
             # check if fetch end then use last doc otherwise use the offset
             if self.fetch_end:
                 self.fetch_end = False
-                q = self.query.query().start_after(self.last_doc)
+                q = self.query.query.start_after(self.last_doc)
             else:
-                q = self.query.query().offset(self.offset)
+                q = self.query.query.offset(self.offset)
 
             # Apply new Limit if there is any
             if limit:
                 q = q.limit(limit)
                 self.offset += limit
             else:
-                self.offset += self.query.n_limit
+                self.offset += self.query._limit
 
             # Update offset in cursor
             self._cursor['offset'] = self.offset

--- a/src/fireo/queries/query_iterator.py
+++ b/src/fireo/queries/query_iterator.py
@@ -38,7 +38,6 @@ class QueryIterator:
                 # Suppose this is the last doc
                 self.last_doc = doc
                 m = query_wrapper.ModelWrapper.from_query_result(self.model_cls(), doc)
-                m._update_doc = self.query._update_doc_key(m)
                 # Suppose this is last doc
                 self.last_doc_key = m.key
                 return m

--- a/src/fireo/queries/query_set.py
+++ b/src/fireo/queries/query_set.py
@@ -134,7 +134,11 @@ class QuerySet:
         kwargs:
             keyword args Direct assign for equal filter
         """
-        return FilterQuery(self.model_cls, parent, *args, **kwargs)
+        query = FilterQuery(self.model_cls, parent)
+        if args or kwargs:
+            query = query.filter(*args, **kwargs)
+
+        return query
 
     def delete(self, key, transaction=None, batch=None, child=False):
         """Delete document from firestore

--- a/src/fireo/utils/cursor.py
+++ b/src/fireo/utils/cursor.py
@@ -1,0 +1,77 @@
+import base64
+import json
+from datetime import datetime
+from typing import Optional, TYPE_CHECKING
+
+from fireo.fields import DateTime
+from fireo.utils.utils import get_nested_field_by_dotted_name
+
+if TYPE_CHECKING:
+    from fireo.queries.query_set import QuerySet
+    from fireo.queries.filter_query import FilterQuery
+
+
+class Cursor(dict):
+    @classmethod
+    def from_string(cls, cursor_string: str):
+        return cls(**json.loads(base64.b64decode(cursor_string)))
+
+    def to_string(self) -> str:
+        return base64.b64encode(json.dumps(self).encode()).decode()
+
+    @classmethod
+    def extract(cls, query: 'FilterQuery') -> 'Cursor':
+        cursor = {}
+        if query.parent:
+            cursor['parent'] = query.parent
+
+        for name, op, val in query.select_query:
+            # ISSUE # 77
+            # if filter value type is datetime then it need to first
+            # convert into string then JSON serialize
+            if isinstance(val, datetime):
+                val = val.isoformat()
+
+            cursor.setdefault('filters', []).append((name, op, val))
+
+        cursor['limit'] = query.n_limit
+
+        if query.order_by:
+            cursor['order'] = ','.join(
+                ('-' if direction == 'DESC' else '') + name
+                for name, direction in query.order_by
+            )
+
+        return cls(**cursor)
+
+    def apply(self, parent: Optional[str], queryset: 'QuerySet') -> 'FilterQuery':
+        if 'parent' in self:
+            parent = self['parent']
+
+        query = queryset.filter(parent)
+
+        if 'filters' in self:
+            for name, op, val in self['filters']:
+                # ISSUE # 77
+                # if field is datetime and type is str (which is usually come from cursor)
+                # then convert this string into datetime format
+                field = get_nested_field_by_dotted_name(queryset.model_cls, name)
+                if isinstance(field, DateTime):
+                    val = datetime.fromisoformat(val)
+
+                query.filter(name, op, val)
+
+        if 'order' in self:
+            query.order(self['order'])
+
+        if 'limit' in self:
+            query.limit(self['limit'])
+
+        # check if last doc key is available or not
+        if 'last_doc_key' in self:
+            query.start_after(key=self['last_doc_key'])
+
+        else:
+            query.offset(self['offset'])
+
+        return query

--- a/src/fireo/utils/utils.py
+++ b/src/fireo/utils/utils.py
@@ -86,30 +86,6 @@ def is_key(str):
     return "/" in str
 
 
-def remove_none_field(values):
-    """Remove None values from dict or list.
-
-    Example:
-        >>> remove_none_field({'a': 1, 'b': None})
-        {'a': 1}
-    """
-    if isinstance(values, list):
-        return [remove_none_field(v) for v in values]
-
-    if not isinstance(values, dict):
-        return values
-
-    result = {}
-    for k, v in values.items():
-        if v is not None:
-            if isinstance(v, (dict, list)):
-                v = remove_none_field(v)
-
-            result[k] = v
-
-    return result
-
-
 def get_db_column_names_for_path(
     model: 'Union[Model, Type[Model]]',
     root_field_name: str,

--- a/src/fireo/utils/utils.py
+++ b/src/fireo/utils/utils.py
@@ -1,7 +1,9 @@
 import re
-from typing import Type, TYPE_CHECKING, Union
+from typing import List, Type, TYPE_CHECKING, Union
 
 from google.cloud import firestore
+
+from fireo.fields import Field
 
 if TYPE_CHECKING:
     from fireo.models.model import Model
@@ -86,28 +88,73 @@ def is_key(str):
     return "/" in str
 
 
-def get_db_column_names_for_path(
+def get_fields_for_path(
     model: 'Union[Model, Type[Model]]',
     root_field_name: str,
     *nested_fields_names: str,
-):
-    """Get db column names for nested fields."""
+) -> List[Field]:
+    """Get fields for path."""
     from fireo.fields import MapField, NestedModelField
     from fireo.fields.errors import AttributeTypeError
 
-    model_field = model._meta.get_field(root_field_name)
-    db_field_path = [model_field.db_column_name]
+    model_field: Field = model._meta.get_field(root_field_name)
+    fields = [model_field]
 
     for p in nested_fields_names:
         if isinstance(model_field, NestedModelField):
             nested_model = model_field.nested_model
             model_field = nested_model._meta.get_field(p)
-            db_field_path.append(model_field.db_column_name)
+            fields.append(model_field)
 
         elif isinstance(model_field, MapField):
-            db_field_path.append(p)
+            break
 
         else:
             raise AttributeTypeError(f"Invalid field type: {model_field}")
 
-    return db_field_path
+    return fields
+
+
+def get_db_column_names_for_path(
+    model: 'Union[Model, Type[Model]]',
+    root_field_name: str,
+    *nested_fields_names: str,
+) -> List[str]:
+    """Get db column names for nested fields."""
+    from fireo.fields import MapField
+
+    fields = get_fields_for_path(model, root_field_name, *nested_fields_names)
+    db_column_names = [f.db_column_name for f in fields]
+    if isinstance(fields[-1], MapField):
+        db_column_names.extend(nested_fields_names[len(fields) - 1:])
+
+    return db_column_names
+
+
+def get_dot_names_as_dot_columns(
+    model: 'Union[Model, Type[Model]]',
+    dotted_name: str,
+) -> str:
+    """Convert dotted names to db column names."""
+    db_column_path = get_db_column_names_for_path(model, *dotted_name.split('.'))
+
+    return '.'.join(db_column_path)
+
+
+def get_nested_field_by_dotted_name(
+    model: 'Union[Model, Type[Model]]',
+    dotted_name: str,
+) -> Field:
+    """Get nested field by dotted name.
+
+    Example:
+        >>> class Nested(Model):
+        ...     field = NumberField()
+        >>>
+        >>> class MyModel(Model):
+        ...     nested = NestedModelField(Nested)
+        >>>
+        >>> get_nested_field_by_dotted_name(MyModel, 'nested.field')
+        <fireo.fields.number.NumberField object at 0x7f8b8c0b7a90>
+    """
+    return get_fields_for_path(model, *dotted_name.split('.'))[-1]

--- a/src/tests/v2.1.0/test_copy_on_change.py
+++ b/src/tests/v2.1.0/test_copy_on_change.py
@@ -1,0 +1,50 @@
+from copy import deepcopy
+
+import fireo
+from fireo.fields import TextField
+from fireo.models import Model
+
+
+class MyModel(Model):
+    first = TextField()
+    second = TextField()
+
+
+def test_copy_filter_query_on_change():
+    MyModel(first='test', second='test').save()
+    MyModel(first='test2', second='test2').save()
+    MyModel(first='test', second='test3').save()
+
+    base_query = MyModel.collection.filter(first='test').order('second')
+    kwargs = deepcopy(base_query._deconstruct())
+    result = list(base_query.fetch())
+    keys = [r.key for r in result]
+
+    assert len(result) == 2
+    assert result[0].first == 'test'
+    assert result[0].second == 'test'
+    assert result[1].first == 'test'
+    assert result[1].second == 'test3'
+    assert base_query.filter(second='test2') is not base_query
+    assert base_query.transaction('fake') is not base_query
+    assert base_query.batch(fireo.batch()) is not base_query
+    assert base_query.limit(1) is not base_query
+    assert base_query.offset(1) is not base_query
+    assert base_query.start_after(first='fake') is not base_query
+    assert base_query.start_at(first='fake') is not base_query
+    assert base_query.end_before(first='fake') is not base_query
+    assert base_query.end_at(first='fake') is not base_query
+    assert base_query.order('first') is not base_query
+    assert base_query.fetch(1)
+    assert base_query.get()
+
+    assert kwargs == base_query._deconstruct()
+    assert [e.key for e in base_query.fetch()] == keys
+
+
+def test_copy_manager_on_change():
+    manager = MyModel.collection
+
+    assert manager is not manager.parent('fake')
+    assert manager._deconstruct()['parent_key'] != 'fake'
+

--- a/src/tests/v2.1.0/test_increment_value.py
+++ b/src/tests/v2.1.0/test_increment_value.py
@@ -1,0 +1,47 @@
+import pytest
+
+import fireo
+from fireo.fields import NumberField
+from fireo.fields.errors import InvalidFieldType
+from fireo.models import Model
+from fireo.models.errors import ModelSerializingWrappedError
+
+
+class MyModel(Model):
+    my_int_field = NumberField(int_only=True)
+    my_float_field = NumberField(float_only=True)
+
+
+def test_increment_value():
+    model = MyModel(
+        my_int_field=fireo.Increment(1),
+        my_float_field=fireo.Increment(2.0),
+    )
+    model.save()
+
+    assert model.my_int_field == 1
+    assert model.my_float_field == 2.0
+
+
+def test_increment_using_float_instead_of_int_raises_error():
+    model = MyModel(
+        my_int_field=fireo.Increment(1.5),
+    )
+
+    with pytest.raises(ModelSerializingWrappedError) as error:
+        model.save()
+
+    assert isinstance(error.value.__cause__, InvalidFieldType)
+    assert 'my_int_field' in str(error.value)
+
+
+def test_increment_using_int_instead_of_float_raises_error():
+    model = MyModel(
+        my_float_field=fireo.Increment(1),
+    )
+
+    with pytest.raises(ModelSerializingWrappedError) as error:
+        model.save()
+
+    assert isinstance(error.value.__cause__, InvalidFieldType)
+    assert 'my_float_field' in str(error.value)


### PR DESCRIPTION
- All operations that changing FilterQuery or Manager now leads to creating a new instance without changing the original one.
- Fix some possible problems with `.filter()` for custom field types and ReferenceField for both flat and nested models.
- NumberField now tries to convert `str` to `int` or `float` to be consistent with the behavior in `.filter()`
- ReferenceField now accepts both `key` or `model` to be consistent with the behavior in `.filter()`