### PR TITLE
Fix typo in typing import

### DIFF
--- a/type-annotation.md
+++ b/type-annotation.md
@@ -50,7 +50,7 @@ Example:
 
 ```python
 from fireo.typedmodel import TypedModel
-from typeing import List, Dict
+from typing import List, Dict
 
 
 class Profile(TypedModel):


### PR DESCRIPTION
Hi, just fixing what I suppose is a typo in the documentation for TypedModel.